### PR TITLE
Improve the handling of YANG model feature and deviation information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ apteryx-rest
 __pycache__/
 sse
 index_html.c
-models/*.xml
+models/ietf-yang-library.xml
+models/ietf-restconf-monitoring.xml
 models/*.h
 
 # Autotools

--- a/models/rfc6243_example.xml
+++ b/models/rfc6243_example.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<MODULE xmlns="http://example.com/ns/interfaces" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/alliedtelesis/apteryx-xml https://github.com/alliedtelesis/apteryx-xml/releases/download/v1.2/apteryx.xsd" model="example" namespace="http://example.com/ns/interfaces" prefix="exam" organization="Dummy Organization" version="2023-04-04" features="ether,fast" deviations="user-example-deviation">
+  <NODE name="interfaces" help="Example interfaces group">
+    <NODE name="interface" help="Example interface entry">
+      <NODE name="*" help="The interface entry with key name">
+        <NODE name="name" mode="rw" help="The administrative name of the interface. This is an identifier that is only unique within the scope of this list, and only within a specific server."/>
+        <NODE name="mtu" mode="rw" default="1500" help="The maximum transmission unit (MTU) value assigned to this interface." range="0..4294967295"/>
+        <NODE name="status" mode="r" default="up" help="The current status of this interface.">
+          <VALUE name="up" value="up"/>
+          <VALUE name="waking up" value="waking up"/>
+          <VALUE name="not feeling so good" value="not feeling so good"/>
+          <VALUE name="better check it out" value="better check it out"/>
+          <VALUE name="better call for help" value="better call for help"/>
+        </NODE>
+      </NODE>
+    </NODE>
+  </NODE>
+</MODULE>

--- a/models/rfc6243_example.yang
+++ b/models/rfc6243_example.yang
@@ -1,0 +1,78 @@
+module example {
+
+     namespace "http://example.com/ns/interfaces";
+
+     prefix exam;
+
+     organization
+        "Dummy Organization";
+
+     revision 2023-04-04 {
+        description
+           "Initial revision";
+     }
+
+     feature ether {
+        description
+          "Interface has attribute ether";
+     }
+
+     feature fast {
+        description
+          "Interface has attribute fast";
+     }
+
+     typedef status-type {
+        description "Interface status";
+        type enumeration {
+          enum up;
+          enum 'waking up';
+          enum 'not feeling so good';
+          enum 'better check it out';
+          enum 'better call for help';
+        }
+        default up;
+     }
+
+     container interfaces {
+         description "Example interfaces group";
+
+         list interface {
+           description "Example interface entry";
+           key name;
+
+           leaf name {
+             description
+               "The administrative name of the interface.
+                This is an identifier that is only unique
+                within the scope of this list, and only
+                within a specific server.";
+             type string {
+               length "1 .. max";
+             }
+           }
+
+           leaf mtu {
+             description
+               "The maximum transmission unit (MTU) value assigned to
+                this interface.";
+             type uint32;
+             default 1500;
+           }
+
+           leaf dummy {
+             description
+               "Dummy field to test a deviation.";
+             type uint32;
+             default 10;
+           }
+
+           leaf status {
+             description
+               "The current status of this interface.";
+             type status-type;
+             config false;
+           }
+         }
+       }
+     }

--- a/models/user-rfc6243_example-deviation.yang
+++ b/models/user-rfc6243_example-deviation.yang
@@ -1,0 +1,29 @@
+module user-example-deviation {
+  yang-version 1;
+  namespace "http://dummy.com/ns/yang/user-example-deviation";
+  prefix user-exam;
+
+  import example {
+    prefix exam;
+  }
+
+  organization
+    "Another Dummy Organization";
+
+  description
+    "This module contains deviation statements for the example module.";
+
+  revision 2023-07-02 {
+    description
+      "Initial revision";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for the
+       Network Configuration Protocol (NETCONF)";
+  }
+
+  deviation "/exam:interfaces/exam:interface/exam:dummy" {
+    deviate not-supported;
+    description
+      "Dummy leaf not supported";
+  }
+}

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -51,6 +51,18 @@ def test_restconf_yang_library_tree():
             {
                 "module": [
                     {
+                        "deviation": [
+                            "user-example-deviation"
+                        ],
+                        "feature": [
+                            "ether",
+                            "fast"
+                        ],
+                        "name": "example",
+                        "namespace": "http://example.com/ns/interfaces",
+                        "revision": "2023-04-04"
+                    },
+                    {
                         "name": "ietf-restconf-monitoring",
                         "namespace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring",
                         "revision": "2017-01-26"

--- a/yang-library.c
+++ b/yang-library.c
@@ -118,6 +118,42 @@ schema_set_model_information (sch_instance *schema, GNode *root)
             {
                 add_leaf_strdup (gnode, MODULES_STATE_MODULE_NAMESPACE, loaded->ns_href);
             }
+            if (loaded->features)
+            {
+                gchar **split;
+                int count;
+                int i;
+
+                split = g_strsplit (loaded->features, ",", 0);
+                count = g_strv_length (split);
+                for (i = 0; i < count; i++)
+                {
+                    char *feature_path;
+                    feature_path =
+                        g_strdup_printf ("%s/%s", YANG_LIBRARY_MODULE_SET_MODULE_FEATURE, split[i]);
+                    add_leaf_strdup (gnode, feature_path, split[i]);
+                    g_free (feature_path);
+                }
+                g_strfreev (split);
+            }
+            if (loaded->deviations)
+            {
+                gchar **split;
+                int count;
+                int i;
+
+                split = g_strsplit (loaded->deviations, ",", 0);
+                count = g_strv_length (split);
+                for (i = 0; i < count; i++)
+                {
+                    char *deviation_path;
+                    deviation_path =
+                        g_strdup_printf ("%s/%s", YANG_LIBRARY_MODULE_SET_MODULE_DEVIATION, split[i]);
+                    add_leaf_strdup (gnode, deviation_path, split[i]);
+                    g_free (deviation_path);
+                }
+                g_strfreev (split);
+            }
         }
     }
 }


### PR DESCRIPTION
The pyang plugin conversion module has been improved such that the generated XML schema for a YANG model now contains information about any model features or deviations. This change uses that information to set a modules information in the ietf-yang-library data.