### PR TITLE
Handle a request to restconf/data (RFC8040 section 3.4.1.2)

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -225,6 +225,11 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
     int qdepth, rdepth;
     int diff;
 
+    /* If a request is made to /restconf/data (in which case the path is now empty) it is analogous to a
+       request to /restconf/data/ietf-yang-library:yang-library */
+    if (!strlen (path) && (flags & FLAGS_RESTCONF))
+        path = "/ietf-yang-library:yang-library";
+
     /* Separate the path from any query string */
     qmark = strchr (path, '?');
     if (qmark)
@@ -925,7 +930,7 @@ rest_api (req_handle handle, int flags, const char *rpath, const char *path,
             rest_api_watch (handle, flags, path);
             return;
         }
-        else if (path[strlen (path) - 1] == '/')
+        else if (strlen (path) && path[strlen (path) - 1] == '/')
             resp = rest_api_search (path, if_none_match, if_modified_since);
         else
             resp = rest_api_get (flags, path, if_none_match, if_modified_since);

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -96,6 +96,67 @@ def test_restconf_yang_library_tree():
 """ % (contentid))
 
 
+def test_restconf_yang_library_data():
+    response = requests.get("{}{}/data".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    tree = response.json()
+    contentid = tree['ietf-yang-library:yang-library']['content-id']
+    assert contentid is not None
+    assert tree == json.loads("""
+{
+    "ietf-yang-library:yang-library": {
+        "content-id": "%s",
+        "module-set": [
+            {
+                "module": [
+                    {
+                        "deviation": [
+                            "user-example-deviation"
+                        ],
+                        "feature": [
+                            "ether",
+                            "fast"
+                        ],
+                        "name": "example",
+                        "namespace": "http://example.com/ns/interfaces",
+                        "revision": "2023-04-04"
+                    },
+                    {
+                        "name": "ietf-restconf-monitoring",
+                        "namespace": "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring",
+                        "revision": "2017-01-26"
+                    },
+                    {
+                        "name": "ietf-yang-library",
+                        "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library",
+                        "revision": "2019-01-04"
+                    },
+                    {
+                        "name": "testing",
+                        "namespace": "http://test.com/ns/yang/testing",
+                        "revision": "2023-01-01"
+                    },
+                    {
+                        "name": "testing-2",
+                        "namespace": "http://test.com/ns/yang/testing-2",
+                        "revision": "2023-02-01"
+                    },
+                    {
+                        "name": "testing2-augmented",
+                        "namespace": "http://test.com/ns/yang/testing2-augmented",
+                        "revision": "2023-02-02"
+                    }
+                ],
+                "name": "modules"
+            }
+        ]
+    }
+}
+""" % (contentid))
+
+
 # module: ietf-restconf-monitoring
 #   +--ro restconf-state
 #      +--ro capabilities


### PR DESCRIPTION
A get request to restconf/data will now return the result of a query to restconf/data/ietf-yang-library:yang-library.