### PR TITLE
Deal with HTTPS servers that pass header precondition fields by just …

### DIFF
--- a/fcgi.c
+++ b/fcgi.c
@@ -195,9 +195,17 @@ handle_http (void *arg)
         goto exit;
     }
     if_match = FCGX_GetParam ("HTTP_IF_MATCH", request->envp);
+    if (!if_match)
+        if_match = FCGX_GetParam ("HTTP_If_Match", request->envp);
     if_none_match = FCGX_GetParam ("HTTP_IF_NONE_MATCH", request->envp);
+    if (!if_none_match)
+        if_none_match = FCGX_GetParam ("HTTP_If-None-Match", request->envp);
     if_modified_since = FCGX_GetParam ("HTTP_IF_MODIFIED_SINCE", request->envp);
+    if (!if_modified_since)
+        if_modified_since = FCGX_GetParam ("HTTP_If-Modified-Since", request->envp);
     if_unmodified_since = FCGX_GetParam ("HTTP_IF_UNMODIFIED_SINCE", request->envp);
+    if (!if_unmodified_since)
+        if_unmodified_since = FCGX_GetParam ("HTTP_If-Unmodified-Since", request->envp);
     length = FCGX_GetParam ("CONTENT_LENGTH", request->envp);
     if (!rpath || !path)
     {


### PR DESCRIPTION
…appending HTTP_

Section 3 of [RFC7232] specifies some precondition header fields:- If-Match
If-None-Match
If-Modified-Since
If-Unmodified-Since

Some HTTPS servers pass this information by adding HTTP_ to the precondition field. Other HTTPS servers translate these preconditon fields into other known strings values. Currently only the second type of HTTPS server work as expected.

This change deals with the first kind of HTTPS server.