### PR TITLE
Add a location header for a successful POST

### DIFF
--- a/fcgi.c
+++ b/fcgi.c
@@ -171,6 +171,7 @@ handle_http (void *arg)
 {
     FCGX_Request *request = (FCGX_Request *) arg;
     char *rpath, *path, *length, *if_match, *if_none_match, *if_modified_since, *if_unmodified_since;
+    char *server_name, *server_port;
     int flags;
     char *data = NULL;
     int len = 0;
@@ -194,6 +195,12 @@ handle_http (void *arg)
         rc = -(flags);
         goto exit;
     }
+    server_port = FCGX_GetParam ("SERVER_PORT", request->envp);
+    server_name = FCGX_GetParam ("SERVER_NAME", request->envp);
+    if (server_name && g_strcmp0 (server_name, "*:80") == 0)
+        server_name = NULL;
+    if (!server_name)
+        server_name = FCGX_GetParam ("SERVER_ADDR", request->envp);
     if_match = FCGX_GetParam ("HTTP_IF_MATCH", request->envp);
     if (!if_match)
         if_match = FCGX_GetParam ("HTTP_If_Match", request->envp);
@@ -227,7 +234,8 @@ handle_http (void *arg)
             }
         }
     }
-    g_cb ((req_handle) request, flags, rpath, path, if_match, if_none_match, if_modified_since, if_unmodified_since, data, len);
+    g_cb ((req_handle) request, flags, rpath, path, if_match, if_none_match, if_modified_since,
+           if_unmodified_since, server_name, server_port, data, len);
 
 exit:
     if (rc)

--- a/internal.h
+++ b/internal.h
@@ -75,6 +75,7 @@ bool is_connected (req_handle handle, bool block);
 typedef void (*req_callback) (req_handle handle, int flags, const char *rpath, const char *path,
                               const char *if_match, const char *if_none_match,
                               const char *if_modified_since, const char *if_unmodified_since,
+                              const char *server_name, const char *server_port,
                               const char *data, int length);
 
 /* FastCGI */
@@ -88,7 +89,7 @@ gboolean rest_init (const char *path);
 void rest_api (req_handle handle, int flags, const char *rpath, const char *path,
                const char *if_match, const char *if_none_match,
                const char *if_modified_since, const char *if_unmodified_since,
-               const char *data, int length);
+               const char *server_name, const char *server_port, const char *data, int length);
 void rest_shutdown (void);
 void yang_library_create (sch_instance *schema);
 void restconf_monitoring_create (sch_instance *schema);


### PR DESCRIPTION
RFC8040, section 4.4.1

If the POST method succeeds, a "201 Created" status-line is returned and there is no response message-body.  A "Location" header field identifying the child resource that was created MUST be present in the response in this case.