### PR TITLE
Fix compliance with RFC8040 section 5.2

### DIFF
--- a/fcgi.c
+++ b/fcgi.c
@@ -118,7 +118,7 @@ get_flags (FCGX_Request * r)
         else
         {
             ERROR ("Media-Type \"%s\" not allowed\n", param);
-            return -415;
+            return -406;
         }
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -376,11 +376,11 @@ def test_restconf_unsupported_method():
 
 def test_restconf_unsupported_encoding():
     response = requests.get("{}{}/data/test".format(server_uri, docroot), auth=server_auth, headers={"Accept": "text/html"})
-    assert response.status_code == 415
+    assert response.status_code == 406
     response = requests.get("{}{}/data/test".format(server_uri, docroot), auth=server_auth, headers={"Accept": "application/xml"})
-    assert response.status_code == 415
+    assert response.status_code == 406
     response = requests.get("{}{}/data/test".format(server_uri, docroot), auth=server_auth, headers={"Accept": "application/yang.data+xml"})
-    assert response.status_code == 415
+    assert response.status_code == 406
     response = requests.post("{}{}/data/test".format(server_uri, docroot), auth=server_auth, headers={"Content-Type": "text/html"}, data="""Hello World""")
     assert response.status_code == 415
     response = requests.post("{}{}/data/test".format(server_uri, docroot), auth=server_auth, headers={"Content-Type": "application/xml"}, data="""<cat></cat>""")


### PR DESCRIPTION
Last paragraph:-
"If the server does not support any of the requested output encodings for a request, then it MUST return an error response with a "406 Not Acceptable" status-line."