### PR TITLE
PUT/PATCH should not change a key leaf value

### DIFF
--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -150,3 +150,15 @@ def test_restconf_replace_if_match_namespace():
 }
     """)
     assert apteryx_get("/test/settings/priority") == "2"
+
+
+def test_restconf_replace_existing_list_key():
+    data = '{"name" : "fox"}'
+    response = requests.put("{}{}/data/test/animals/animal=cat".format(server_uri, docroot), auth=server_auth, data=data, headers=set_restconf_headers)
+    assert response.status_code == 405
+
+
+def test_restconf_replace_existing_list_non_key():
+    data = '{"colour" : "pink"}'
+    response = requests.put("{}{}/data/test/animals/animal=cat".format(server_uri, docroot), auth=server_auth, data=data, headers=set_restconf_headers)
+    assert response.status_code == 204

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -72,3 +72,15 @@ def test_restconf_update_missing_list_entry():
     """)
     assert apteryx_get("/test/animals/animal/frog/name") == "Not found"
     assert apteryx_get("/test/animals/animal/frog/type") == "Not found"
+
+
+def test_restconf_update_existing_list_key():
+    data = '{"name" : "fox"}'
+    response = requests.patch("{}{}/data/test/animals/animal=cat".format(server_uri, docroot), auth=server_auth, data=data, headers=set_restconf_headers)
+    assert response.status_code == 405
+
+
+def test_restconf_update_existing_list_non_key():
+    data = '{"colour" : "pink"}'
+    response = requests.patch("{}{}/data/test/animals/animal=cat".format(server_uri, docroot), auth=server_auth, data=data, headers=set_restconf_headers)
+    assert response.status_code == 204


### PR DESCRIPTION
RFC8040 section 4.5 "The PUT method MUST NOT be used to change the key leaf values for a data resource instance." RFC8040 section 4.6.1 "The PATCH method MUST NOT be used to change the key leaf values for a data resource instance."

This patch adds code to protect against such changes.