### PR TITLE
Make the error tag to status code compliant with RFC8040 section 7.

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -207,13 +207,13 @@ def test_restconf_create_invalid_enum():
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads("""
 {
-    "ietf-restconf:errors" : {
-        "error" : [
-        {
-            "error-type" : "application",
-            "error-tag" : "malformed-message",
-            "error-message" : "malformed request syntax"
-        }
+    "ietf-restconf:errors": {
+        "error": [
+            {
+                "error-message": "Invalid input parameter",
+                "error-tag": "invalid-value",
+                "error-type": "application"
+            }
         ]
     }
 }
@@ -359,13 +359,13 @@ def test_restconf_create_list_leaf_integer_invalid():
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads("""
 {
-    "ietf-restconf:errors" : {
-        "error" : [
-        {
-            "error-type" : "application",
-            "error-tag" : "malformed-message",
-            "error-message" : "malformed request syntax"
-        }
+    "ietf-restconf:errors": {
+        "error": [
+            {
+                "error-message": "Invalid input parameter",
+                "error-tag": "invalid-value",
+                "error-type": "application"
+            }
         ]
     }
 }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -51,17 +51,17 @@ def test_restconf_query_invalid_queries():
         print(json.dumps(response.json(), indent=4, sort_keys=True))
         assert response.headers["Content-Type"] == "application/yang-data+json"
         assert response.json() == json.loads("""
-    {
-        "ietf-restconf:errors" : {
-            "error" : [
+{
+    "ietf-restconf:errors": {
+        "error": [
             {
-                "error-type" : "application",
-                "error-tag" : "malformed-message",
-                "error-message" : "malformed request syntax"
+                "error-message": "Invalid input parameter",
+                "error-tag": "invalid-value",
+                "error-type": "application"
             }
-            ]
-        }
+        ]
     }
+}
         """)
 
 


### PR DESCRIPTION
Previously the error tag was set based on the status code. This however is not sufficient for some status codes that may have multiple possible error tags.