### PR TITLE
Add support for RFC3986 section 2.1 % encoded characters

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <ctype.h>
 #include <stdbool.h>
 #include <string.h>
 #include <sys/sysinfo.h>

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -399,6 +399,23 @@ def test_restconf_get_leaf_list_integers():
     """)
 
 
+def test_restconf_get_percent_encoded_fields():
+    response = requests.get("{}{}/data/testing:test/animals/animal=mouse?fields=colour%3Btype".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "testing:animal": [
+        {
+            "colour": "grey",
+            "type": "little"
+        }
+    ]
+}
+    """)
+
+
 # TODO multiple keys
 #  /restconf/data/ietf-yang-library:modules-state/module=ietf-interfaces,2014-05-08
 #  Missing key values are not allowed, so two consecutive commas are


### PR DESCRIPTION
RFC3986 section 2.1 specifies that special characters can be encoded in the pattern: "%" HEXDIG HEXDIG

This change adds support for decoding such % encoding in the requesting path.