### PR TITLE
Fix depth check for removing wildcard from query tree

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -432,7 +432,7 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
             /* Nothing in the database, but we may have defaults! */
             tree = query;
             query = NULL;
-            if ((g_node_max_height (tree) - 1) > qdepth)
+            if (g_node_max_height (tree) > qdepth)
             {
                 GNode *child = g_node_first_child (qnode);
                 qnode->children = NULL;


### PR DESCRIPTION
Previously apteryx_query incorrectly added NULL nodes which meant our depth check was one out. That has now been fixed so we can use the actual tree depth to tell if we need to remove an added wildcard or not.