### PR TITLE
Support translated YANG models.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -63,6 +63,7 @@ fi
 rm -f $BUILD/etc/apteryx/schema/*
 cp $BUILD/apteryx-xml/models/*.xml $BUILD/etc/apteryx/schema/
 cp $BUILD/apteryx-xml/models/*.map $BUILD/etc/apteryx/schema/
+cp $BUILD/apteryx-xml/models/*.xlat $BUILD/etc/apteryx/schema/
 
 # Check fcgi
 if [ ! -d fcgi-2.4.0 ]; then

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -429,3 +429,20 @@ def test_restconf_create_list_entry_exists():
 }
     """)
     assert apteryx_get("/test/animals/animal/cat/type") == "1"
+
+
+def test_restconf_create_list_leaf_string_ok_translate():
+    tree = """
+{
+    "toy": [
+        "ball",
+        "mouse"
+    ]
+}
+"""
+    response = requests.post("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal=cat/toys".format(server_uri, docroot),
+                             auth=server_auth, data=tree, headers=set_restconf_headers)
+    assert response.status_code == 201
+    print(apteryx_traverse("/test/animals/animal/cat"))
+    assert apteryx_get("/test/animals/animal/cat/toys/toy/ball") == "ball"
+    assert apteryx_get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -158,3 +158,23 @@ def test_restconf_delete_list_by_path_select_two():
     assert apteryx_get("/test/animals/animal/hamster/food/banana/type") == "Not found"
     assert apteryx_get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
     assert apteryx_get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'
+
+
+def test_restconf_delete_trunk_ns_default_translate():
+    response = requests.delete("{}{}/data/xlat-test:xlat-test/xlat-animals".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
+    assert response.status_code == 204
+    assert len(response.content) == 0
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert response.json() == json.loads('{}')
+
+
+def test_restconf_delete_list_by_path_select_two_translate():
+    response = requests.delete("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal/hamster/food/banana".format(server_uri, docroot),
+                               auth=server_auth, headers=set_restconf_headers)
+    assert response.status_code == 204
+    assert len(response.content) == 0
+    assert apteryx_get("/test/animals/animal/hamster/food/banana/name") == "Not found"
+    assert apteryx_get("/test/animals/animal/hamster/food/banana/type") == "Not found"
+    assert apteryx_get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
+    assert apteryx_get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -416,6 +416,126 @@ def test_restconf_get_percent_encoded_fields():
     """)
 
 
+def test_restconf_get_list_trunk_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animals": {
+        "xlat-animal": [
+            {"name": "cat", "type": "fast"},
+            {"name": "dog", "colour": "brown"},
+            {"name": "hamster", "type": "slow", "food": [
+                    {"name": "banana", "type": "fruit"},
+                    {"name": "nuts", "type": "kibble"}
+                ]
+            },
+            {"name": "mouse", "type": "slow", "colour": "grey"},
+            {"name": "parrot", "type": "fast", "colour": "blue", "toys": {
+                "toy": ["puzzles", "rings"]
+                }
+            }
+        ]
+    }
+}
+    """)
+
+
+def test_restconf_get_list_select_none_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animal": [
+        {"name": "cat", "type": "fast"},
+        {"name": "dog", "colour": "brown"},
+        {"name": "hamster", "type": "slow", "food": [
+                {"name": "banana", "type": "fruit"},
+                {"name": "nuts", "type": "kibble"}
+            ]
+        },
+        {"name": "mouse", "colour": "grey", "type": "slow"},
+        {"name": "parrot", "type": "fast", "colour": "blue", "toys": {
+            "toy": ["puzzles", "rings"]
+            }
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_get_list_select_one_trunk_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal=cat".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animal": [
+        {
+            "name": "cat",
+            "type": "fast"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_get_list_select_one_by_path_trunk_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal/cat".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animal": [
+        {
+            "name": "cat",
+            "type": "fast"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_get_list_select_two_trunk_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal=hamster/food=banana".format(server_uri, docroot),
+                            auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:food": [
+        {
+            "name": "banana",
+            "type": "fruit"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_get_leaf_list_node_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals/xlat-animal=parrot/toys/toy".format(server_uri, docroot),
+                            auth=server_auth, headers=get_restconf_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "xlat-test:toy": [
+        "puzzles",
+        "rings"
+    ]
+}
+    """)
+
+
 # TODO multiple keys
 #  /restconf/data/ietf-yang-library:modules-state/module=ietf-interfaces,2014-05-08
 #  Missing key values are not allowed, so two consecutive commas are

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -908,6 +908,106 @@ def test_restconf_query_with_defaults_report_all_list():
     """)
 
 
+def test_restconf_query_depth_4_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals?depth=4".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animals": {
+        "xlat-animal": [
+            {
+                "name": "cat",
+                "type": "fast"
+            },
+            {
+                "colour": "brown",
+                "name": "dog"
+            },
+            {
+                "food": [
+                    {
+                        "name": "banana",
+                        "type": "fruit"
+                    },
+                    {
+                        "name": "nuts",
+                        "type": "kibble"
+                    }
+                ],
+                "name": "hamster",
+                "type": "slow"
+            },
+            {
+                "colour": "grey",
+                "name": "mouse",
+                "type": "slow"
+            },
+            {
+                "colour": "blue",
+                "name": "parrot",
+                "type": "fast"
+            }
+        ]
+    }
+}
+    """)
+
+
+def test_restconf_query_depth_5_translate():
+    response = requests.get("{}{}/data/xlat-test:xlat-test/xlat-animals?depth=5".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "xlat-test:xlat-animals": {
+        "xlat-animal": [
+            {
+                "name": "cat",
+                "type": "fast"
+            },
+            {
+                "colour": "brown",
+                "name": "dog"
+            },
+            {
+                "food": [
+                    {
+                        "name": "banana",
+                        "type": "fruit"
+                    },
+                    {
+                        "name": "nuts",
+                        "type": "kibble"
+                    }
+                ],
+                "name": "hamster",
+                "type": "slow"
+            },
+            {
+                "colour": "grey",
+                "name": "mouse",
+                "type": "slow"
+            },
+            {
+                "colour": "blue",
+                "name": "parrot",
+                "toys": {
+                    "toy": [
+                        "puzzles",
+                        "rings"
+                    ]
+                },
+                "type": "fast"
+            }
+        ]
+    }
+}
+    """)
+
+
 # POST /restconf/data/example-jukebox:jukebox/playlist=Foo-One?insert=first
 # POST /restconf/data/example-jukebox:jukebox/playlist=Foo-One?insert=after&point=%2Fexample-jukebox%3Ajukebox%2Fplaylist%3DFoo-One%2Fsong%3D1
 

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -97,6 +97,11 @@ def test_restconf_yang_library_tree():
                         "name": "testing2-augmented",
                         "namespace": "http://test.com/ns/yang/testing2-augmented",
                         "revision": "2023-02-02"
+                    },
+                    {
+                        "name": "xlat-test",
+                        "namespace": "http://test.com/ns/yang/xlat-testing",
+                        "revision": "2023-01-01"
                     }
                 ],
                 "name": "common"
@@ -177,6 +182,11 @@ def test_restconf_yang_library_data():
                         "name": "testing2-augmented",
                         "namespace": "http://test.com/ns/yang/testing2-augmented",
                         "revision": "2023-02-02"
+                    },
+                    {
+                        "name": "xlat-test",
+                        "namespace": "http://test.com/ns/yang/xlat-testing",
+                        "revision": "2023-01-01"
                     }
                 ],
                 "name": "common"


### PR DESCRIPTION
This change allows one model to be translated to another model. This is useful if multiple YANG models for the same type of data exist. In this case a back-end super YANG model is created which is a combination of the contributing models, and requests to the individual models are translated into a request of the super model and responses are translated back into the individual requesting models.