### PR TITLE
A change in apteryx-xml/schema.c has highlighted two bad tests

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -740,7 +740,6 @@ def test_restconf_query_with_defaults_report_all_trunk_data():
     "settings": {
         "debug": "disable",
         "enable": true,
-        "empty": {},
         "priority": 1,
         "readonly": "yes",
         "time": {
@@ -774,7 +773,6 @@ def test_restconf_query_with_defaults_report_all_trunk_empty():
 {
     "settings": {
         "debug": "disable",
-        "empty": {},
         "enable": false,
         "readonly": "yes",
         "time": {


### PR DESCRIPTION
Two tests that are supposed to return the default settings for a query, were also returning the name of an empty container.