### PR TITLE
Improve the translation of models

### DIFF
--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -425,17 +425,18 @@ def test_restconf_get_list_trunk_translate():
 {
     "xlat-test:xlat-animals": {
         "xlat-animal": [
-            {"name": "cat", "type": "fast"},
-            {"name": "dog", "colour": "brown"},
+            {"name": "cat", "type": "fast", "food": [{"pet": "cat"}]},
+            {"name": "dog", "colour": "brown", "food": [{"pet": "dog"}]},
             {"name": "hamster", "type": "slow", "food": [
                     {"name": "banana", "type": "fruit"},
-                    {"name": "nuts", "type": "kibble"}
+                    {"name": "nuts", "type": "kibble"},
+                    {"pet": "hamster"}
                 ]
             },
-            {"name": "mouse", "type": "slow", "colour": "grey"},
+            {"name": "mouse", "type": "slow", "colour": "grey", "food": [{"pet": "mouse"}]},
             {"name": "parrot", "type": "fast", "colour": "blue", "toys": {
                 "toy": ["puzzles", "rings"]
-                }
+                }, "food": [{"pet": "parrot"}]
             }
         ]
     }
@@ -451,17 +452,19 @@ def test_restconf_get_list_select_none_translate():
     assert response.json() == json.loads("""
 {
     "xlat-test:xlat-animal": [
-        {"name": "cat", "type": "fast"},
-        {"name": "dog", "colour": "brown"},
+        {"name": "cat", "type": "fast", "food": [{"pet": "cat"}]},
+        {"name": "dog", "colour": "brown", "food": [{"pet": "dog"}]},
         {"name": "hamster", "type": "slow", "food": [
                 {"name": "banana", "type": "fruit"},
-                {"name": "nuts", "type": "kibble"}
+                {"name": "nuts", "type": "kibble"},
+                {"pet": "hamster"}
             ]
         },
-        {"name": "mouse", "colour": "grey", "type": "slow"},
+        {"name": "mouse", "colour": "grey", "type": "slow", "food": [{"pet": "mouse"}]},
         {"name": "parrot", "type": "fast", "colour": "blue", "toys": {
             "toy": ["puzzles", "rings"]
-            }
+            },
+            "food": [{"pet": "parrot"}]
         }
     ]
 }
@@ -478,7 +481,8 @@ def test_restconf_get_list_select_one_trunk_translate():
     "xlat-test:xlat-animal": [
         {
             "name": "cat",
-            "type": "fast"
+            "type": "fast",
+            "food": [{"pet": "cat"}]
         }
     ]
 }
@@ -495,7 +499,8 @@ def test_restconf_get_list_select_one_by_path_trunk_translate():
     "xlat-test:xlat-animal": [
         {
             "name": "cat",
-            "type": "fast"
+            "type": "fast",
+            "food": [{"pet": "cat"}]
         }
     ]
 }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -916,11 +916,21 @@ def test_restconf_query_depth_4_translate():
     "xlat-test:xlat-animals": {
         "xlat-animal": [
             {
+                "food": [
+                    {
+                        "pet": "cat"
+                    }
+                ],
                 "name": "cat",
                 "type": "fast"
             },
             {
                 "colour": "brown",
+                "food": [
+                    {
+                        "pet": "dog"
+                    }
+                ],
                 "name": "dog"
             },
             {
@@ -932,6 +942,9 @@ def test_restconf_query_depth_4_translate():
                     {
                         "name": "nuts",
                         "type": "kibble"
+                    },
+                    {
+                        "pet": "hamster"
                     }
                 ],
                 "name": "hamster",
@@ -939,11 +952,21 @@ def test_restconf_query_depth_4_translate():
             },
             {
                 "colour": "grey",
+                "food": [
+                    {
+                        "pet": "mouse"
+                    }
+                ],
                 "name": "mouse",
                 "type": "slow"
             },
             {
                 "colour": "blue",
+                "food": [
+                    {
+                        "pet": "parrot"
+                    }
+                ],
                 "name": "parrot",
                 "type": "fast"
             }
@@ -963,11 +986,21 @@ def test_restconf_query_depth_5_translate():
     "xlat-test:xlat-animals": {
         "xlat-animal": [
             {
+                "food": [
+                    {
+                        "pet": "cat"
+                    }
+                ],
                 "name": "cat",
                 "type": "fast"
             },
             {
                 "colour": "brown",
+                "food": [
+                    {
+                        "pet": "dog"
+                    }
+                ],
                 "name": "dog"
             },
             {
@@ -979,6 +1012,9 @@ def test_restconf_query_depth_5_translate():
                     {
                         "name": "nuts",
                         "type": "kibble"
+                    },
+                    {
+                        "pet": "hamster"
                     }
                 ],
                 "name": "hamster",
@@ -986,11 +1022,21 @@ def test_restconf_query_depth_5_translate():
             },
             {
                 "colour": "grey",
+                "food": [
+                    {
+                        "pet": "mouse"
+                    }
+                ],
                 "name": "mouse",
                 "type": "slow"
             },
             {
                 "colour": "blue",
+                "food": [
+                    {
+                        "pet": "parrot"
+                    }
+                ],
                 "name": "parrot",
                 "toys": {
                     "toy": [


### PR DESCRIPTION
When multiple external translation paths map to a single internal path, then only the first external map translation was occurring. This has been fixed by passing the original query to sch_translate_output so it can determine which fields need reporting.

Due to changes in xlat_test.xml and xlat_test.xlat some expected test results have changed.