### PR TITLE
Allow the user to limit the models loaded by apteryx-rest

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -86,7 +86,7 @@ void fcgi_stop (void);
 /* Rest */
 extern bool rest_use_arrays;
 extern bool rest_use_types;
-gboolean rest_init (const char *path);
+gboolean rest_init (const char *path, const char *supported);
 void rest_api (req_handle handle, int flags, const char *rpath, const char *path,
                const char *if_match, const char *if_none_match,
                const char *if_modified_since, const char *if_unmodified_since,

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ help (char *app_name)
             "  -a   enable the use of JSON arrays for lists\n"
             "  -t   encode values as JSON types where possible\n"
             "  -m   search <path> for modules\n"
+            "  -n   name of a file containing a list of supported models\n"
             "  -p   use <pidfile> (defaults to " DEFAULT_APP_PID ")\n"
             "  -s   rest socket <socket> (defaults to " DEFAULT_REST_SOCK ")\n", app_name);
 }
@@ -67,11 +68,12 @@ main (int argc, char *argv[])
     const char *socket = DEFAULT_REST_SOCK;
     int i = 0;
     bool background = false;
+    char *supported = NULL;
     FILE *fp = NULL;
     int rc = EXIT_SUCCESS;
 
     /* Parse options */
-    while ((i = getopt (argc, argv, "bdvatm:s:p:e:h")) != -1)
+    while ((i = getopt (argc, argv, "bdvatm:n:s:p:e:h")) != -1)
     {
         switch (i)
         {
@@ -112,6 +114,9 @@ main (int argc, char *argv[])
         case 'm':
             path = optarg;
             break;
+        case 'n':
+            supported = optarg;
+            break;
         case 's':
             socket = optarg;
             break;
@@ -143,7 +148,7 @@ main (int argc, char *argv[])
     apteryx_init (verbose);
 
     /* Initialise rest */
-    if (!rest_init (path))
+    if (!rest_init (path, supported))
     {
         ERROR ("ERROR: Failed to load modules at path \"%s\"\n", path);
         rc = EXIT_FAILURE;

--- a/rest.c
+++ b/rest.c
@@ -1203,7 +1203,7 @@ rest_api (req_handle handle, int flags, const char *rpath, const char *path,
 }
 
 gboolean
-rest_init (const char *path)
+rest_init (const char *path, const char *supported)
 {
     struct sysinfo info;
     struct timespec monotime;
@@ -1218,7 +1218,7 @@ rest_init (const char *path)
     g_boottime += (monotime.tv_sec - monotime_raw.tv_sec);
 
     /* Load Data Models */
-    g_schema = sch_load (path);
+    g_schema = sch_load_with_model_list_filename (path, supported);
     if (!g_schema)
     {
         return false;


### PR DESCRIPTION
A new startup option "-n" has been added so the user can specify a file containing a list of supported models. All other models in the schema directory, not listed in the supported models file, will not be loaded. If the option "-n" is not present in the command line, then all models will be loaded.