### PR TITLE
Add support for XML proxy nodes in rest/restconf operations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,10 @@ def apteryx_traverse(path):
     return subprocess.check_output("%s -t %s%s" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
 
 
+def apteryx_proxy(path, url):
+    assert subprocess.check_output('%s -x %s%s "%s"' % (APTERYX, APTERYX_URL, path, url), shell=True).strip().decode('utf-8') != "Failed"
+
+
 @pytest.fixture(autouse=True)
 def run_around_tests():
     # Before test

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -79,6 +79,11 @@ def test_restconf_yang_library_tree():
                         "revision": "2019-01-04"
                     },
                     {
+                        "name": "logical-elements",
+                        "namespace": "http://example.com/ns/logical-elements",
+                        "revision": "2024-04-04"
+                    },
+                    {
                         "name": "testing",
                         "namespace": "http://test.com/ns/yang/testing",
                         "revision": "2023-01-01"
@@ -157,6 +162,11 @@ def test_restconf_yang_library_data():
                         "name": "ietf-yang-library",
                         "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library",
                         "revision": "2019-01-04"
+                    },
+                    {
+                        "name": "logical-elements",
+                        "namespace": "http://example.com/ns/logical-elements",
+                        "revision": "2024-04-04"
                     },
                     {
                         "name": "testing",


### PR DESCRIPTION
XML proxy nodes allow a schema to branch to using a remote apteryx database to operate on. The actual code to support proxy nodes is in apteryx-xml/schema.c. This change adds tests for a proxy node.