### PR TITLE
Improve the logging to allow an audit trail for restconf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = apteryx-rest
-apteryx_rest_SOURCES = main.c fcgi.c rest.c yang-library.c api_html.c
+apteryx_rest_SOURCES = main.c fcgi.c rest.c yang-library.c api_html.c logging.c
 apteryx_rest_CFLAGS = @LIBFCGI_CFLAGS@ @APTERYX_XML_CFLAGS@ @JANSSON_CFLAGS@ @LIBXML2_CFLAGS@ @APTERYX_CFLAGS@ @GLIB_CFLAGS@
 apteryx_rest_LDADD = @LIBFCGI_LIBS@ @APTERYX_XML_LIBS@ @JANSSON_LIBS@ @LIBXML2_LIBS@ @APTERYX_LIBS@ @GLIB_LIBS@
 

--- a/fcgi.c
+++ b/fcgi.c
@@ -25,6 +25,8 @@
 #include <fcgi_config.h>
 #include <fcgiapp.h>
 
+#define UNKNOWN_STR "unknown"
+
 static req_callback g_cb;
 static const char *g_socket = NULL;
 static int g_sock = -1;
@@ -174,7 +176,7 @@ handle_http (void *arg)
 {
     FCGX_Request *request = (FCGX_Request *) arg;
     char *rpath, *path, *length, *if_match, *if_none_match, *if_modified_since, *if_unmodified_since;
-    char *server_name, *server_port;
+    char *server_name, *server_port, *remote_addr, *remote_user;
     int flags;
     char *data = NULL;
     int len = 0;
@@ -204,6 +206,12 @@ handle_http (void *arg)
         server_name = NULL;
     if (!server_name)
         server_name = FCGX_GetParam ("SERVER_ADDR", request->envp);
+    remote_addr = FCGX_GetParam("REMOTE_ADDR", request->envp);
+    if (!remote_addr)
+        remote_addr = UNKNOWN_STR;
+    remote_user = FCGX_GetParam("REMOTE_USER", request->envp);
+    if (!remote_user)
+        remote_user = UNKNOWN_STR;
     if_match = FCGX_GetParam ("HTTP_IF_MATCH", request->envp);
     if (!if_match)
         if_match = FCGX_GetParam ("HTTP_If-Match", request->envp);
@@ -238,7 +246,7 @@ handle_http (void *arg)
         }
     }
     g_cb ((req_handle) request, flags, rpath, path, if_match, if_none_match, if_modified_since,
-           if_unmodified_since, server_name, server_port, data, len);
+           if_unmodified_since, server_name, server_port, remote_addr, remote_user, data, len);
 
 exit:
     if (rc)

--- a/internal.h
+++ b/internal.h
@@ -48,6 +48,17 @@ extern bool verbose;
 #define NOTICE(fmt, args...) { if (debug) printf (fmt, ## args); else syslog (LOG_NOTICE, fmt, ## args); }
 #define ERROR(fmt, args...) { if (debug) printf (fmt, ## args); else syslog (LOG_CRIT, fmt, ## args); }
 
+typedef enum
+{
+    LOG_NONE                    = 0,
+    LOG_POST                    = (1 << 0),  /* Log POST requests */
+    LOG_PUT                     = (1 << 1),  /* Log PUT requests */
+    LOG_PATCH                   = (1 << 2),  /* Log PATCH requests */
+    LOG_DELETE                  = (1 << 3),  /* Log DELETE requests */
+    LOG_GET                     = (1 << 4),  /* Log GET requests */
+    LOG_HEAD                    = (1 << 5),  /* Log HEAD requests */
+} logging_flags;
+
 /* HTTP handler for rest */
 #define FLAGS_METHOD_POST           (1 << 0)
 #define FLAGS_METHOD_GET            (1 << 1)
@@ -77,6 +88,7 @@ typedef void (*req_callback) (req_handle handle, int flags, const char *rpath, c
                               const char *if_match, const char *if_none_match,
                               const char *if_modified_since, const char *if_unmodified_since,
                               const char *server_name, const char *server_port,
+                              const char *remote_addr, const char *remote_user,
                               const char *data, int length);
 
 /* FastCGI */
@@ -90,9 +102,17 @@ gboolean rest_init (const char *path);
 void rest_api (req_handle handle, int flags, const char *rpath, const char *path,
                const char *if_match, const char *if_none_match,
                const char *if_modified_since, const char *if_unmodified_since,
-               const char *server_name, const char *server_port, const char *data, int length);
+               const char *server_name, const char *server_port,
+               const char *remote_addr, const char *remote_user,
+               const char *data, int length);
 void rest_shutdown (void);
 void yang_library_create (sch_instance *schema);
 void restconf_monitoring_create (sch_instance *schema);
+
+/* Logging */
+extern int logging;
+
+void logging_shutdown (void);
+int logging_init (const char *path, const char *logging_arg);
 
 #endif /* _REST_H_ */

--- a/logging.c
+++ b/logging.c
@@ -1,0 +1,164 @@
+/**
+ * @file logging.c
+ * Handler of the logging configuration file
+ *
+ * Copyright 2024, Allied Telesis Labs New Zealand, Ltd
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library. If not, see <http://www.gnu.org/licenses/>
+ */
+#include "internal.h"
+#include <sys/inotify.h>
+
+#define READ_BUF_SIZE 512
+
+static int inotify_fd = -1;
+static GIOChannel *channel = NULL;
+static char *logging_filename = NULL;
+
+/* Logging flags */
+int logging = LOG_NONE;
+
+static int
+load_logging_options (void)
+{
+    FILE *fp = NULL;
+    gchar **split;
+    char *buf;
+    int count;
+    int i;
+    logging_flags flags = LOG_NONE;
+    int ret = 0;
+
+    buf = g_malloc0 (READ_BUF_SIZE);
+    fp = fopen (logging_filename, "r");
+    if (fp && buf)
+    {
+        if (fgets (buf, READ_BUF_SIZE, fp) != NULL)
+        {
+            /* Remove any trailing LF */
+            buf[strcspn(buf, "\n")] = '\0';
+            split = g_strsplit (buf, " ", 6);
+            count = g_strv_length (split);
+            for (i = 0; i < count; i++)
+            {
+                if (g_strcmp0 (split[i], "post") == 0)
+                    flags |= LOG_POST;
+                else if (g_strcmp0 (split[i], "put") == 0)
+                    flags |= LOG_PUT;
+                else if (g_strcmp0 (split[i], "patch") == 0)
+                    flags |= LOG_PATCH;
+                else if (g_strcmp0 (split[i], "delete") == 0)
+                    flags |= LOG_DELETE;
+                else if (g_strcmp0 (split[i], "get") == 0)
+                    flags |= LOG_GET;
+                else if (g_strcmp0 (split[i], "head") == 0)
+                    flags |= LOG_HEAD;
+            }
+            g_strfreev (split);
+        }
+        fclose (fp);
+    }
+    else
+    {
+        ret = -1;
+    }
+    g_free (buf);
+    logging = flags;
+
+    return ret;
+}
+
+/**
+ * Handles an inotify event indicating that the logging options file may have
+ * been modified and reloads the logging options in the file if necessary
+ */
+static int
+logging_file_update (void)
+{
+    char *buf;
+    int len;
+    int ret = -1;
+
+    /* Got a notify event informing the logging file has been modified */
+    if (inotify_fd >= 0)
+    {
+        buf = g_malloc0 (READ_BUF_SIZE);
+        len = read (inotify_fd, buf, READ_BUF_SIZE);
+        if (len)
+            ret = load_logging_options ();
+
+        g_free (buf);
+    }
+
+    return ret;
+}
+
+static gboolean
+logging_options_reload (GIOChannel *source, GIOCondition condition, gpointer data)
+{
+    logging_file_update ();
+    return TRUE;
+}
+
+static int
+logging_open_inotify (void)
+{
+    if (inotify_fd < 0)
+    {
+        /* inotify doesn't tell us about creation of the tracelog_control file
+         * unless we listen to inotify events for the whole directory */
+        inotify_fd = inotify_init ();
+        inotify_add_watch (inotify_fd, logging_filename,
+                           IN_MODIFY | IN_DELETE | IN_MOVE);
+    }
+
+    return inotify_fd;
+}
+
+void
+logging_shutdown (void)
+{
+    if (inotify_fd >= 0)
+        close (inotify_fd);
+
+    if (channel)
+        g_io_channel_shutdown (channel, false, NULL);
+
+    if (logging_filename)
+        g_free (logging_filename);
+}
+
+int
+logging_init (const char *path, const char *logging_arg)
+{
+    if (!path || !logging_arg)
+        return -1;
+
+    logging_filename = g_strdup_printf ("%s/%s", path, logging_arg);
+
+    /* Read the current setting */
+    if (load_logging_options () < 0)
+        return -1;
+
+    /* Add an inotify watch for logging changes */
+    if (logging_open_inotify () < 0)
+        return -1;
+
+    channel = g_io_channel_unix_new (logging_open_inotify ());
+    g_io_add_watch (channel, G_IO_IN, logging_options_reload, NULL);
+
+    openlog ("restconf", LOG_PID | LOG_NDELAY, LOG_USER);
+
+    return 0;
+}


### PR DESCRIPTION
For security reasons a device should be capable of generating an audit log of all modifications made to a device.

This change allows the logging down to the leaf level of any modifications made to the configuration via restconf.