### PR TITLE
Add support for XML proxy nodes in rest/restconf operations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,10 @@ def apteryx_traverse(path):
     return subprocess.check_output("%s -t %s%s" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
 
 
+def apteryx_proxy(path, url):
+    assert subprocess.check_output('%s -x %s%s "%s"' % (APTERYX, APTERYX_URL, path, url), shell=True).strip().decode('utf-8') != "Failed"
+
+
 @pytest.fixture(autouse=True)
 def run_around_tests():
     # Before test

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, get_restconf_headers
+from conftest import server_uri, server_auth, docroot, apteryx_set, get_restconf_headers, apteryx_proxy
 
 
 def test_restconf_query_empty():
@@ -1116,6 +1116,24 @@ def test_restconf_query_with_defaults_report_all_list():
             "name": "mildred"
         }
     ]
+}
+    """)
+
+
+def test_restconf_query_proxy_with_defaults_report_all_leaf():
+    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx_set("/logical-elements/logical-element/loop/root", "root")
+    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx_set("/test/settings/debug", "")
+    response = requests.get("{}{}/data/logical-elements:logical-elements/logical-element/loopy/test/settings/debug?with-defaults=report-all".format(server_uri, docroot),
+                            auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "testing:debug": "disable"
 }
     """)
 

--- a/tests/test_yang_library.py
+++ b/tests/test_yang_library.py
@@ -79,6 +79,11 @@ def test_restconf_yang_library_tree():
                         "revision": "2019-01-04"
                     },
                     {
+                        "name": "logical-elements",
+                        "namespace": "http://example.com/ns/logical-elements",
+                        "revision": "2024-04-04"
+                    },
+                    {
                         "name": "testing",
                         "namespace": "http://test.com/ns/yang/testing",
                         "revision": "2023-01-01"
@@ -162,6 +167,11 @@ def test_restconf_yang_library_data():
                         "name": "ietf-yang-library",
                         "namespace": "urn:ietf:params:xml:ns:yang:ietf-yang-library",
                         "revision": "2019-01-04"
+                    },
+                    {
+                        "name": "logical-elements",
+                        "namespace": "http://example.com/ns/logical-elements",
+                        "revision": "2024-04-04"
                     },
                     {
                         "name": "testing",


### PR DESCRIPTION
XML proxy nodes allow a schema to branch to using a remote apteryx database to operate on. The actual code to support proxy nodes is in apteryx-xml/schema.c. This change just adds tests for a proxy node.