### PR TITLE
Modify the tests to test RFC7951#section-6.8 compliance

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -614,6 +614,8 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
         schflags |= SCH_F_JSON_ARRAYS;
     if (flags & FLAGS_JSON_FORMAT_TYPES)
         schflags |= SCH_F_JSON_TYPES;
+    if (flags & FLAGS_RESTCONF)
+        schflags |= SCH_F_IDREF_VALUES;
     if (flags & FLAGS_JSON_FORMAT_NS)
     {
         schflags |= SCH_F_NS_MODEL_NAME;

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -242,15 +242,15 @@ def test_restconf_get_list_trunk():
 {
     "testing:animals": {
         "animal": [
-            {"name": "cat", "type": "big"},
+            {"name": "cat", "type": "animal-testing-types:big"},
             {"name": "dog", "colour": "brown"},
-            {"name": "hamster", "type": "little", "food": [
+            {"name": "hamster", "type": "animal-testing-types:little", "food": [
                     {"name": "banana", "type": "fruit"},
                     {"name": "nuts", "type": "kibble"}
                 ]
             },
-            {"name": "mouse", "colour": "grey", "type": "little"},
-            {"name": "parrot", "type": "big", "colour": "blue", "toys": {
+            {"name": "mouse", "colour": "grey", "type": "animal-testing-types:little"},
+            {"name": "parrot", "type": "animal-testing-types:big", "colour": "blue", "toys": {
                 "toy": ["puzzles", "rings"]
                 }
             }
@@ -269,15 +269,15 @@ def test_restconf_get_list_trunk_no_namespace():
 {
     "animals": {
         "animal": [
-            {"name": "cat", "type": "big"},
+            {"name": "cat", "type": "animal-testing-types:big"},
             {"name": "dog", "colour": "brown"},
-            {"name": "hamster", "type": "little", "food": [
+            {"name": "hamster", "type": "animal-testing-types:little", "food": [
                     {"name": "banana", "type": "fruit"},
                     {"name": "nuts", "type": "kibble"}
                 ]
             },
-            {"name": "mouse", "colour": "grey", "type": "little"},
-            {"name": "parrot", "type": "big", "colour": "blue", "toys": {
+            {"name": "mouse", "colour": "grey", "type": "animal-testing-types:little"},
+            {"name": "parrot", "type": "animal-testing-types:big", "colour": "blue", "toys": {
                 "toy": ["puzzles", "rings"]
                 }
             }
@@ -295,15 +295,15 @@ def test_restconf_get_list_select_none():
     assert response.json() == json.loads("""
 {
     "animal": [
-        {"name": "cat", "type": "big"},
+        {"name": "cat", "type": "animal-testing-types:big"},
         {"name": "dog", "colour": "brown"},
-        {"name": "hamster", "type": "little", "food": [
+        {"name": "hamster", "type": "animal-testing-types:little", "food": [
                 {"name": "banana", "type": "fruit"},
                 {"name": "nuts", "type": "kibble"}
             ]
         },
-        {"name": "mouse", "colour": "grey", "type": "little"},
-        {"name": "parrot", "type": "big", "colour": "blue", "toys": {
+        {"name": "mouse", "colour": "grey", "type": "animal-testing-types:little"},
+        {"name": "parrot", "type": "animal-testing-types:big", "colour": "blue", "toys": {
             "toy": ["puzzles", "rings"]
             }
         }
@@ -322,7 +322,7 @@ def test_restconf_get_list_select_one_trunk():
     "testing:animal": [
         {
             "name": "cat",
-            "type": "big"
+            "type": "animal-testing-types:big"
         }
     ]
 }
@@ -339,7 +339,7 @@ def test_restconf_get_list_select_one_by_path_trunk():
     "testing:animal": [
         {
             "name": "cat",
-            "type": "big"
+            "type": "animal-testing-types:big"
         }
     ]
 }
@@ -409,7 +409,7 @@ def test_restconf_get_percent_encoded_fields():
     "testing:animal": [
         {
             "colour": "grey",
-            "type": "little"
+            "type": "animal-testing-types:little"
         }
     ]
 }
@@ -456,7 +456,7 @@ def test_restconf_get_proxy_list_select_one_trunk():
     "testing:animal": [
         {
             "name": "cat",
-            "type": "big"
+            "type": "animal-testing-types:big"
         }
     ]
 }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -329,7 +329,7 @@ def test_restconf_query_depth_4():
         "animal": [
             {
                 "name": "cat",
-                "type": "big"
+                "type": "animal-testing-types:big"
             },
             {
                 "colour": "brown",
@@ -347,17 +347,17 @@ def test_restconf_query_depth_4():
                     }
                 ],
                 "name": "hamster",
-                "type": "little"
+                "type": "animal-testing-types:little"
             },
             {
                 "colour": "grey",
                 "name": "mouse",
-                "type": "little"
+                "type": "animal-testing-types:little"
             },
             {
                 "colour": "blue",
                 "name": "parrot",
-                "type": "big"
+                "type": "animal-testing-types:big"
             }
         ]
     }
@@ -376,7 +376,7 @@ def test_restconf_query_depth_5():
         "animal": [
             {
                 "name": "cat",
-                "type": "big"
+                "type": "animal-testing-types:big"
             },
             {
                 "colour": "brown",
@@ -394,12 +394,12 @@ def test_restconf_query_depth_5():
                     }
                 ],
                 "name": "hamster",
-                "type": "little"
+                "type": "animal-testing-types:little"
             },
             {
                 "colour": "grey",
                 "name": "mouse",
-                "type": "little"
+                "type": "animal-testing-types:little"
             },
             {
                 "colour": "blue",
@@ -410,7 +410,7 @@ def test_restconf_query_depth_5():
                         "rings"
                     ]
                 },
-                "type": "big"
+                "type": "animal-testing-types:big"
             }
         ]
     }
@@ -558,7 +558,7 @@ def test_restconf_query_field_list_one_specific_node():
     assert response.json() == json.loads("""
 {
     "animal": [{
-        "type": "little"
+        "type": "animal-testing-types:little"
     }]
 }
 """)
@@ -573,7 +573,7 @@ def test_restconf_query_field_list_two_specific_nodes():
 {
     "animal": [{
         "name": "mouse",
-        "type": "little"
+        "type": "animal-testing-types:little"
     }]
 }
 """)
@@ -726,16 +726,16 @@ def test_restconf_query_field_mixed_index_1():
     "animals": {
         "animal": {
             "cat": {
-                "type": "1"
+                "type": "animal-testing-types:1"
             },
             "hamster": {
-                "type": "2"
+                "type": "animal-testing-types:2"
             },
             "mouse": {
                 "name": "mouse"
             },
             "parrot": {
-                "type": "1"
+                "type": "animal-testing-types:1"
             }
         }
     }


### PR DESCRIPTION
RFC7951 https://datatracker.ietf.org/doc/html/rfc7951#section-6.8

A change was made to apteryx-xml schema.c to support RFC7951#section-6.8 compliance. An additional change to test.xml changed the responses in certain tests. This change modifies the various tests to reflect the expected modified output.