### PR TITLE
Allow non restconf RPC's without properly formatted input

### DIFF
--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1877,6 +1877,46 @@ def test_restapi_rpc_with_input():
     assert apteryx_get("/t4:test/state/age") == "55"
 
 
+def test_restapi_rpc_with_input_invalid():
+    data = """{ "delay": "cabbage" }"""
+    response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
+    assert response.status_code == 400
+    assert len(response.content) == 0
+    assert apteryx_get("/t4:test/state/age") == "Not found"
+
+
+def test_restapi_rpc_with_simple_input_integer():
+    data = """55"""
+    response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
+    assert response.status_code == 204
+    assert len(response.content) == 0
+    assert apteryx_get("/t4:test/state/age") == "55"
+
+
+def test_restapi_rpc_with_simple_input_quoted():
+    data = '"55"'
+    response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
+    assert response.status_code == 204
+    assert len(response.content) == 0
+    assert apteryx_get("/t4:test/state/age") == "55"
+
+
+def test_restapi_rpc_with_simple_input_invalid():
+    data = """cabbage"""
+    response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
+    assert response.status_code == 400
+    assert len(response.content) == 0
+    assert apteryx_get("/t4:test/state/age") == "Not found"
+
+
+def test_restapi_rpc_with_simple_input_integer_outofrange():
+    data = """-1"""
+    response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
+    assert response.status_code == 400
+    assert len(response.content) == 0
+    assert apteryx_get("/t4:test/state/age") == "Not found"
+
+
 def test_restapi_rpc_invalid_get_operation():
     response = requests.get("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth)
     assert response.status_code == 405
@@ -1890,6 +1930,15 @@ def test_restapi_rpc_with_output():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert response.json() == json.loads("""{ "last-reset": "5" }""")
+
+
+def test_restapi_rpc_with_output_integer():
+    apteryx_set("/t4:test/state/age", "5")
+    response = requests.post("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth, headers=json_headers)
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/json"
+    assert response.json() == json.loads("""{ "last-reset": 5 }""")
 
 
 def test_restapi_rpc_get_with_output():

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -67,6 +67,34 @@ def test_restconf_rpc_invalid_input():
     """)
 
 
+def test_restconf_rpc_invalid_value():
+    data = """
+{
+    "input": {
+        "delay": "notanint",
+        "message": "Rebooting because I can"
+    }
+}
+"""
+    response = requests.post("{}{}/operations/testing-4:reboot".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
+    assert response.status_code == 400
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.headers["Content-Type"] == "application/yang-data+json"
+    assert response.json() == json.loads("""
+{
+    "ietf-restconf:errors" : {
+        "error" : [
+        {
+            "error-type" : "application",
+            "error-tag" : "invalid-value"
+        }
+        ]
+    }
+}
+    """)
+
+
 def test_restconf_rpc_invalid_path():
     response = requests.post("{}{}/operations/testing-4:reboot/input/delay".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 404


### PR DESCRIPTION
e.g. sending just the 'value' instead of '{key: value}'