### PR TITLE
Add support for read-only proxy trees

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -940,7 +940,7 @@ rest_api_post (int flags, const char *path, const char *data, int length, const 
     rest_e_tag error_tag = REST_E_TAG_NONE;
 
     /* Parsing options - always set arrays and types */
-    schflags = SCH_F_JSON_ARRAYS | SCH_F_JSON_TYPES;
+    schflags = SCH_F_JSON_ARRAYS | SCH_F_JSON_TYPES | SCH_F_MODIFY_DATA;
     if (verbose)
         schflags |= SCH_F_DEBUG;
     if (flags & FLAGS_JSON_FORMAT_NS)
@@ -1196,7 +1196,7 @@ rest_api_delete (int flags, const char *path, const char *remote_user, const cha
     char *name = NULL;
     int rc = HTTP_CODE_NO_CONTENT;
     rest_e_tag error_tag = REST_E_TAG_NONE;
-    int schflags = 0;
+    int schflags = SCH_F_MODIFY_DATA; /* We are going to modify the tree */
 
     /* Parsing options */
     if (verbose)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -180,3 +180,26 @@ def test_restconf_delete_proxy_list_select_one():
     assert apteryx_get("/test/animals/animal/cat/name") == 'cat'
     assert apteryx_get('/test/animals/animal/dog/name') == "Not found"
     assert apteryx_get('/test/animals/animal/dog/colour') == "Not found"
+
+
+def test_restconf_delete_proxy_list_select_one_read_only():
+    apteryx_set("/logical-elements/logical-element-ro/loop/name", "loopy")
+    apteryx_set("/logical-elements/logical-element-ro/loop/root", "root")
+    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx_proxy("/logical-elements/logical-element-ro/loopy/*", "tcp://127.0.0.1:9999")
+    response = requests.delete("{}{}/data/logical-elements:logical-elements/logical-element-ro/loopy/testing:test/animals/animal=dog".format(server_uri, docroot),
+                               auth=server_auth, headers=set_restconf_headers)
+    assert response.status_code == 404
+    assert response.json() == json.loads("""
+{
+    "ietf-restconf:errors" : {
+        "error" : [
+        {
+            "error-message": "uri path not found",
+            "error-type" : "application",
+            "error-tag" : "invalid-value"
+        }
+        ]
+    }
+}
+    """)


### PR DESCRIPTION
This change allows a remote apteryx database to be mounted at a proxy node as a read only tree.

Two new tests have been added to test this functionality.