### PR TITLE
Fix RFC 8040 compliance for the HEAD and OPTION parameters

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -397,12 +397,21 @@ def test_restconf_unsupported_encoding():
     assert response.status_code == 415
 
 
-def test_restconf_options():
-    response = requests.options("{}{}/data/".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+def test_restconf_options_rw():
+    response = requests.options("{}{}/data/test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) == 0
-    assert response.headers["allow"] == "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
-    # assert response.headers["accept-patch"] == "application/yang-data+xml, application/yang-data+json"
+    assert response.headers["allow"] == "GET,HEAD,OPTIONS,POST,PUT,PATCH,DELETE"
+    assert response.headers["accept-patch"] == "application/yang-data+json"
+    assert response.headers["accept-patch"] == "application/yang-data+json"
+
+
+def test_restconf_options_r():
+    response = requests.options("{}{}/data/test/state/counter".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) == 0
+    assert response.headers["allow"] == "GET,HEAD,OPTIONS"
+    assert response.headers["accept-patch"] == "application/yang-data+json"
     assert response.headers["accept-patch"] == "application/yang-data+json"
 
 


### PR DESCRIPTION
The current HEAD option is returning the body of the get request, when it should not. This causes POSTMAN to reject the response.

The current OPTION parameter is returning all options no matter what the associated requested path is.

Both these issues have been fixed, and the tests updated.