### PR TITLE
Handle list keys with a '/' in the value

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -1674,24 +1674,18 @@ rest_decode_uri (char *path)
 
     while (*in)
     {
-        if(*in == '%' && strlen (in) > 2 && isxdigit (in[1]) && isxdigit (in[2]))
+        uint8_t value;
+
+        /* We decode all escaped special characters except '/'. W3C
+           recommendations suggest that while '/' in a path indicates
+           hierarchical structure, '%2F' does not and is only interpreted
+           by the application layer. Hence we conclude that it is not
+           likely that a user would encode a '/' that was supposed to
+           be part of the path.
+         */
+        if (sscanf (in, "%%%02hhx", &value) == 1 && value != 0x2F)
         {
-            char char_1;
-            char char_2;
-
-            char_1 = toupper (in[1]);
-            if(char_1 >= 'A')
-                char_1 -= ('A' - 10);
-            else
-                char_1 -= '0';
-
-            char_2 = toupper (in[2]);
-            if(char_2 >= 'A')
-                char_2 -= ('A' - 10);
-            else
-                char_2 -= '0';
-
-            *out++ = (char_1 * 16) + char_2;
+            *out++ = (char) value;
             in +=3;
         }
         else

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,11 +65,11 @@ db_default = [
 
 
 def apteryx_set(path, value):
-    assert subprocess.check_output('%s -s %s%s -- "%s"' % (APTERYX, APTERYX_URL, path, value), shell=True).strip().decode('utf-8') != "Failed"
+    assert subprocess.check_output("%s -s '%s%s' -- '%s'" % (APTERYX, APTERYX_URL, path, value), shell=True).strip().decode('utf-8') != "Failed"
 
 
 def apteryx_get(path):
-    return subprocess.check_output("%s -g %s%s" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
+    return subprocess.check_output("%s -g '%s%s'" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
 
 
 def apteryx_prune(path):

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1046,6 +1046,21 @@ def test_restapi_set_leaf_list_invalid():
     assert response.status_code == 400
 
 
+def test_restapi_set_leaf_list_array():
+    data = """
+{
+    "toy": [
+        "ball",
+        "mouse"
+    ]
+}
+    """
+    response = requests.post("{}{}/test/animals/animal/cat/toys".format(server_uri, docroot), verify=False, auth=server_auth, headers={"X-JSON-Array": "on"}, data=data)
+    assert response.status_code == 201
+    assert apteryx_get("/test/animals/animal/cat/toys/toy/ball") == "ball"
+    assert apteryx_get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"
+
+
 def test_restapi_set_tree_list_full_arrays():
     tree = """
 {


### PR DESCRIPTION
It is valid to have a / in the key value, but must be encoded in rest URI's to avoid being interpreted as a path element. As you are not allowed to encode normal path elements using %2F we can avoid decoding it and hence keep it encoded while processing. We store the encoded value as part of the apteryx path.

Add tests for / in the key as well as other reserved characters.