### PR TITLE
Convert apteryx usage in tests to use cdll

### DIFF
--- a/tests/apteryx.py
+++ b/tests/apteryx.py
@@ -1,0 +1,134 @@
+import ctypes
+import os
+
+from ctypes.util import find_library
+
+
+apteryxpath = os.path.abspath(os.path.dirname(__file__) + "/../.build/apteryx/libapteryx.so")
+
+DEBUG = False
+UINT64_MAX = 18446744073709551615
+
+c_libc = ctypes.cdll.LoadLibrary(find_library("c"))
+c_libc.malloc.argtypes = [ctypes.c_size_t]
+c_libc.malloc.restype = ctypes.c_void_p
+c_libc.free.argtypes = [ctypes.c_void_p]
+
+
+class GList(ctypes.Structure):
+    pass
+
+
+GList._fields_ = [
+    ("data", ctypes.c_char_p),
+    ("next", ctypes.POINTER(GList)),
+    ("prev", ctypes.POINTER(GList))
+]
+
+
+class GNode(ctypes.Structure):
+    def __init__(self, data, next=None, prev=None, parent=None, children=None):
+        super(GNode, self).__init__(data, next, prev, parent, children)
+
+
+GNode._fields_ = [
+    ("data", ctypes.c_char_p),
+    ("next", ctypes.POINTER(GNode)),
+    ("prev", ctypes.POINTER(GNode)),
+    ("parent", ctypes.POINTER(GNode)),
+    ("children", ctypes.POINTER(GNode))
+]
+
+
+c_apteryx = ctypes.cdll.LoadLibrary(apteryxpath)
+c_apteryx.apteryx_init(DEBUG)
+c_apteryx_set_full = c_apteryx.apteryx_set_full
+c_apteryx_set_full.restype = ctypes.c_bool
+c_apteryx_get = c_apteryx.apteryx_get
+c_apteryx_get.restype = ctypes.c_char_p
+c_apteryx_prune = c_apteryx.apteryx_prune
+c_apteryx_prune.restype = ctypes.c_bool
+c_apteryx_search = c_apteryx.apteryx_search
+c_apteryx_search.restype = ctypes.POINTER(GList)
+c_apteryx_set_tree_full = c_apteryx.apteryx_set_tree_full
+c_apteryx_set_tree_full.argtypes = [ctypes.POINTER(GNode), ctypes.c_int, ctypes.c_bool]
+c_apteryx_set_tree_full.restype = ctypes.c_bool
+c_apteryx_get_tree = c_apteryx.apteryx_get_tree
+c_apteryx_get_tree.restype = ctypes.POINTER(GNode)
+c_apteryx_proxy = c_apteryx.apteryx_proxy
+c_apteryx_proxy.restype = ctypes.c_bool
+c_apteryx_unproxy = c_apteryx.apteryx_unproxy
+c_apteryx_unproxy.restype = ctypes.c_bool
+
+
+def set(path, value):
+    return c_apteryx_set_full(path.encode('utf-8'), value.encode('utf-8'), UINT64_MAX, False)
+
+
+def get(path):
+    value = c_apteryx_get(path.encode('utf-8'))
+    if bool(value):
+        return value.decode('utf-8')
+    return None
+
+
+def prune(path):
+    return c_apteryx_prune(path.encode('utf-8'))
+
+
+def search(path):
+    c_paths = c_apteryx_search(path.encode('utf-8'))
+    paths = []
+    while bool(c_paths):
+        paths.append(c_paths.contents.data.decode('utf-8'))
+        c_paths = c_paths.contents.next
+    return paths
+
+
+def set_tree(tree):
+    def get_children(children):
+        first = None
+        last = None
+        for key, value in children.items():
+            node = GNode(data=key.encode('utf-8'))
+            if type(value) is dict:
+                node.children = get_children(value)
+            else:
+                node.children = ctypes.pointer(GNode(data=value.encode('utf-8')))
+            if first is None:
+                first = node
+            if last is not None:
+                last.next = ctypes.pointer(node)
+            last = node
+        return ctypes.pointer(first)
+    rname = next(iter(tree))
+    c_tree = GNode(data=('/' + rname).encode('utf-8'))
+    c_tree.children = get_children(tree[rname])
+    return c_apteryx_set_tree_full(c_tree, UINT64_MAX, False)
+
+
+def get_tree(path):
+    def get_children(c_node):
+        nodes = {}
+        while bool(c_node):
+            c_child = c_node.contents.children
+            if bool(c_node.contents.children) and bool(c_child.contents.children):
+                nodes[c_node.contents.data.decode('utf-8')] = get_children(c_child)
+            else:
+                nodes[c_node.contents.data.decode('utf-8')] = c_child.contents.data.decode('utf-8')
+            c_node = c_node.contents.next
+        return nodes
+    c_root = c_apteryx_get_tree(path.encode('utf-8'))
+    tree = {}
+    if bool(c_root):
+        key = os.path.basename(os.path.normpath(c_root.contents.data.decode('utf-8')))
+        tree[key] = get_children(c_root.contents.children)
+    return tree
+
+
+def proxy(path, url):
+    return c_apteryx_proxy(path.encode('utf-8'), url.encode('utf-8'))
+
+
+def unproxy(path, url):
+    return c_apteryx_unproxy(path.encode('utf-8'), url.encode('utf-8'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import apteryx
 import json
 import os
 import pytest
@@ -13,10 +14,6 @@ server_auth = None
 # server_uri = 'https://192.168.6.2:443'
 # server_auth = requests.auth.HTTPBasicAuth('manager', 'friend')
 docroot = '/api'
-
-APTERYX = 'LD_LIBRARY_PATH=.build/usr/lib .build/usr/bin/apteryx'
-# APTERYX_URL='tcp://192.168.6.2:9999:'
-APTERYX_URL = ''
 
 get_restconf_headers = {"Accept": "application/yang-data+json"}
 set_restconf_headers = {"Content-Type": "application/yang-data+json"}
@@ -64,41 +61,20 @@ db_default = [
 ]
 
 
-def apteryx_set(path, value):
-    assert subprocess.check_output("%s -s '%s%s' -- '%s'" % (APTERYX, APTERYX_URL, path, value), shell=True).strip().decode('utf-8') != "Failed"
-
-
-def apteryx_get(path):
-    return subprocess.check_output("%s -g '%s%s'" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
-
-
-def apteryx_prune(path):
-    assert subprocess.check_output("%s -r %s%s" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8') != "Failed"
-
-
-def apteryx_traverse(path):
-    return subprocess.check_output("%s -t %s%s" % (APTERYX, APTERYX_URL, path), shell=True).strip().decode('utf-8')
-
-
-def apteryx_proxy(path, url):
-    assert subprocess.check_output('%s -x %s%s "%s"' % (APTERYX, APTERYX_URL, path, url), shell=True).strip().decode('utf-8') != "Failed"
-
-
 @pytest.fixture(autouse=True)
 def run_around_tests():
     # Before test
     os.system("echo Before test")
-    os.system("%s -r /test" % (APTERYX))
-    apteryx_prune("/test")
-    apteryx_prune("/t2:test")
-    apteryx_prune("/test3")
-    apteryx_prune("/t4:test")
+    apteryx.prune("/test")
+    apteryx.prune("/t2:test")
+    apteryx.prune("/test3")
+    apteryx.prune("/t4:test")
     for path, value in db_default:
-        apteryx_set(path, value)
+        apteryx.set(path, value)
     yield
     # After test
     os.system("echo After test")
-    apteryx_prune("/test")
-    apteryx_prune("/t2:test")
-    apteryx_prune("/test3")
-    apteryx_prune("/t4:test")
+    apteryx.prune("/test")
+    apteryx.prune("/t2:test")
+    apteryx.prune("/test3")
+    apteryx.prune("/t4:test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,9 @@
+import apteryx
 import json
 import pytest
 import requests
 import time
-from conftest import server_uri, server_auth, docroot, apteryx_set, get_restconf_headers, set_restconf_headers
+from conftest import server_uri, server_auth, docroot, get_restconf_headers, set_restconf_headers
 
 
 @pytest.mark.skip(reason="requires target specific http server configuration")
@@ -88,7 +89,7 @@ def test_restconf_get_timestamp_config_changes():
     print(response.headers.get("Last-Modified"))
     timestamp = response.headers.get("Last-Modified")
     time.sleep(1)
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.headers.get("Last-Modified") is not None and response.headers.get("Last-Modified") != timestamp
 
@@ -99,7 +100,7 @@ def test_restconf_get_timestamp_state_no_change():
     print(response.headers.get("Last-Modified"))
     timestamp = response.headers.get("Last-Modified")
     time.sleep(1)
-    apteryx_set("/test/settings/readonly", "false")
+    apteryx.set("/test/settings/readonly", "false")
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.headers.get("Last-Modified") is not None and response.headers.get("Last-Modified") == timestamp
 
@@ -116,7 +117,7 @@ def test_restconf_get_if_modified_since():
     assert response.status_code == 304
     assert len(response.content) == 0
     time.sleep(1)
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/test/settings/enable".format(server_uri, docroot), auth=server_auth, headers=headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -137,7 +138,7 @@ def test_restconf_get_if_modified_since_namespace():
     assert response.status_code == 304
     assert len(response.content) == 0
     time.sleep(1)
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/testing:test/settings/enable".format(server_uri, docroot), auth=server_auth, headers=headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -176,7 +177,7 @@ def test_restconf_get_etag_config_changes():
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(response.headers.get("ETag"))
     etag = response.headers.get("ETag")
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.headers.get("ETag") is not None and response.headers.get("ETag") != etag
 
@@ -186,7 +187,7 @@ def test_restconf_get_etag_state_no_change():
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(response.headers.get("ETag"))
     etag = response.headers.get("ETag")
-    apteryx_set("/test/settings/readonly", "false")
+    apteryx.set("/test/settings/readonly", "false")
     response = requests.get("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.headers.get("ETag") is not None and response.headers.get("ETag") == etag
 
@@ -201,7 +202,7 @@ def test_restconf_get_if_none_match():
     response = requests.get("{}{}/data/test/settings/enable".format(server_uri, docroot), auth=server_auth, headers={**get_restconf_headers, 'If-None-Match': etag})
     assert response.status_code == 304
     assert len(response.content) == 0
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/test/settings/enable".format(server_uri, docroot), auth=server_auth, headers={**get_restconf_headers, 'If-None-Match': etag})
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -221,7 +222,7 @@ def test_restconf_get_if_none_match_namespace():
     response = requests.get("{}{}/data/testing:test/settings/enable".format(server_uri, docroot), auth=server_auth, headers=headers)
     assert response.status_code == 304
     assert len(response.content) == 0
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/testing:test/settings/enable".format(server_uri, docroot), auth=server_auth, headers=headers)
     assert response.status_code == 200
     assert len(response.content) > 0

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,73 +1,74 @@
+import apteryx
 import json
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_get, apteryx_traverse, set_restconf_headers, apteryx_proxy, apteryx_prune
+from conftest import server_uri, server_auth, docroot, set_restconf_headers
 
 
 def test_restconf_create_single_node_ns_none():
-    apteryx_set("/test/settings/priority", "")
+    apteryx.set("/test/settings/priority", "")
     data = """{"priority": "2"}"""
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_create_single_node_ns_aug_none():
-    apteryx_set("/test/settings/volume", "")
+    apteryx.set("/test/settings/volume", "")
     data = """{"volume": "2"}"""
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/volume") == "2"
+    assert apteryx.get("/test/settings/volume") == "2"
 
 
 def test_restconf_create_single_node_ns_default():
-    apteryx_set("/test/settings/priority", "")
+    apteryx.set("/test/settings/priority", "")
     data = """{"priority": "2"}"""
     response = requests.post("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_create_single_node_ns_aug_default():
-    apteryx_set("/test/settings/volume", "")
+    apteryx.set("/test/settings/volume", "")
     data = """{"volume": "2"}"""
     response = requests.post("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/volume") == "2"
+    assert apteryx.get("/test/settings/volume") == "2"
 
 
 def test_restconf_create_single_node_ns_other():
-    apteryx_set("/t2:test/settings/priority", "")
+    apteryx.set("/t2:test/settings/priority", "")
     data = """{"priority": "3"}"""
     response = requests.post("{}{}/data/testing-2:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/t2:test/settings/priority") == "3"
+    assert apteryx.get("/t2:test/settings/priority") == "3"
 
 
 def test_restconf_create_single_node_ns_aug_other():
-    apteryx_set("/t2:test/settings/speed", "")
+    apteryx.set("/t2:test/settings/speed", "")
     data = """{"testing2-augmented:speed": "3"}"""
     response = requests.post("{}{}/data/testing-2:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/t2:test/settings/speed") == "3"
+    assert apteryx.get("/t2:test/settings/speed") == "3"
 
 
 def test_restconf_create_string():
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/test/settings/description", "")
     data = """{"description": "this is a description"}"""
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "this is a description"
+    assert apteryx.get("/test/settings/description") == "this is a description"
 
 
 def test_restconf_create_existing_string():
-    apteryx_set("/test/settings/description", "already set")
+    apteryx.set("/test/settings/description", "already set")
     data = """{"description": "this is a description"}"""
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 409
@@ -87,15 +88,15 @@ def test_restconf_create_existing_string():
     }
 }
     """)
-    assert apteryx_get("/test/settings/description") == "already set"
+    assert apteryx.get("/test/settings/description") == "already set"
 
 
 def test_restconf_create_null():
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/test/settings/description", "")
     data = """{"description": ""}"""
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
-    assert apteryx_get("/test/settings/description") == "Not found"
+    assert apteryx.get("/test/settings/description") is None
 
 
 def test_restconf_create_readonly():
@@ -117,7 +118,7 @@ def test_restconf_create_readonly():
     }
 }
     """)
-    assert apteryx_get("/test/state/counter") == "42"
+    assert apteryx.get("/test/state/counter") == "42"
 
 
 def test_restconf_create_invalid_path():
@@ -164,7 +165,7 @@ def test_restconf_create_invalid_leaf():
 
 
 def test_restconf_create_invalid_json():
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/test/settings/description", "")
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data="""{"description":""")
     assert response.status_code == 400
     assert len(response.content) > 0
@@ -186,20 +187,20 @@ def test_restconf_create_invalid_json():
 
 
 def test_restconf_create_enum():
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/debug", "")
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data="""{"debug": "disable"}""")
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "0"
-    apteryx_set("/test/settings/debug", "")
+    assert apteryx.get("/test/settings/debug") == "0"
+    apteryx.set("/test/settings/debug", "")
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data="""{"debug": "enable"}""")
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "1"
+    assert apteryx.get("/test/settings/debug") == "1"
 
 
 def test_restconf_create_invalid_enum():
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/debug", "")
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data="""{"debug": "cabbage"}""")
     assert response.status_code == 400
     assert len(response.content) > 0
@@ -218,7 +219,7 @@ def test_restconf_create_invalid_enum():
     }
 }
     """)
-    assert apteryx_get("/test/settings/debug") == "Not found"
+    assert apteryx.get("/test/settings/debug") is None
 
 
 def test_restconf_create_hidden():
@@ -239,7 +240,7 @@ def test_restconf_create_hidden():
     }
 }
     """)
-    assert apteryx_get("/test/settings/hidden") == "friend"
+    assert apteryx.get("/test/settings/hidden") == "friend"
 
 
 def test_restconf_create_out_of_range_integer():
@@ -259,7 +260,7 @@ def test_restconf_create_out_of_range_integer():
         ("""{"priority": 18446744073709551615}""", 400)
     ]
     for data, rc in tests:
-        apteryx_set("/test/settings/priority", "")
+        apteryx.set("/test/settings/priority", "")
         response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
         assert response.status_code == rc
 
@@ -273,7 +274,7 @@ def test_restconf_create_out_of_range_uint64():
         ("""{"volume": "28446744073709551615"}""", 400)
     ]
     for data, rc in tests:
-        apteryx_set("/test/settings/volume", "")
+        apteryx.set("/test/settings/volume", "")
         response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
         assert response.status_code == rc
 
@@ -288,7 +289,7 @@ def test_restconf_create_out_of_range_int64():
         ("""{"speed": "18446744073709551615"}""", 400)
     ]
     for data, rc in tests:
-        apteryx_set("/t2:test/settings/speed", "")
+        apteryx.set("/t2:test/settings/speed", "")
         response = requests.post("{}{}/data/testing-2:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
         assert response.status_code == rc
 
@@ -305,8 +306,8 @@ def test_restconf_create_list_entry_ok():
 """
     response = requests.post("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 201
-    print(apteryx_traverse("/test/animals/animal/frog"))
-    assert apteryx_get("/test/animals/animal/frog/name") == "frog"
+    print(apteryx.get_tree("/test/animals/animal/frog"))
+    assert apteryx.get("/test/animals/animal/frog/name") == "frog"
 
 
 def test_restconf_create_list_entry_reserved_key():
@@ -321,10 +322,10 @@ def test_restconf_create_list_entry_reserved_key():
 """
     response = requests.post("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 201
-    print(apteryx_traverse("/test/animals/animal"))
+    print(apteryx.get_tree("/test/animals/animal"))
     for c in characters:
         key = f"skinny%{ord(c):02X}frog" if (c in escaped) else f"skinny{c}frog"
-        assert apteryx_get(f"/test/animals/animal/{key}/name") == f"skinny{c}frog"
+        assert apteryx.get(f"/test/animals/animal/{key}/name") == f"skinny{c}frog"
 
 
 def test_restconf_create_list_leaf_string_ok():
@@ -338,9 +339,9 @@ def test_restconf_create_list_leaf_string_ok():
 """
     response = requests.post("{}{}/data/test/animals/animal=cat/toys".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 201
-    print(apteryx_traverse("/test/animals/animal/cat"))
-    assert apteryx_get("/test/animals/animal/cat/toys/toy/ball") == "ball"
-    assert apteryx_get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"
+    print(apteryx.get_tree("/test/animals/animal/cat"))
+    assert apteryx.get("/test/animals/animal/cat/toys/toy/ball") == "ball"
+    assert apteryx.get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"
 
 
 def test_restconf_create_list_leaf_reserved_in_key():
@@ -357,7 +358,7 @@ def test_restconf_create_list_leaf_reserved_in_key():
     assert response.status_code == 201
     for c in characters:
         key = f"red%{ord(c):02X}ball" if (c in escaped) else f"red{c}ball"
-        assert apteryx_get(f"/test/animals/animal/cat/toys/toy/{key}") == f"red{c}ball"
+        assert apteryx.get(f"/test/animals/animal/cat/toys/toy/{key}") == f"red{c}ball"
 
 
 def test_restconf_create_list_leaf_integer_ok():
@@ -369,12 +370,12 @@ def test_restconf_create_list_leaf_integer_ok():
     ]
 }
 """
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.post("{}{}/data/test/settings/users=fred".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 201
-    print(apteryx_traverse("/test/settings/users"))
-    assert apteryx_get("/test/settings/users/fred/groups/1") == "1"
-    assert apteryx_get("/test/settings/users/fred/groups/5") == "5"
+    print(apteryx.get_tree("/test/settings/users"))
+    assert apteryx.get("/test/settings/users/fred/groups/1") == "1"
+    assert apteryx.get("/test/settings/users/fred/groups/5") == "5"
 
 
 def test_restconf_create_list_leaf_integer_invalid():
@@ -386,7 +387,7 @@ def test_restconf_create_list_leaf_integer_invalid():
     ]
 }
 """
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.post("{}{}/data/test/settings/users=fred".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 400
     assert len(response.content) > 0
@@ -405,9 +406,9 @@ def test_restconf_create_list_leaf_integer_invalid():
     }
 }
     """)
-    print(apteryx_traverse("/test/settings/users"))
-    assert apteryx_get("/test/settings/users/fred/groups/cat") != "cat"
-    assert apteryx_get("/test/settings/users/fred/groups/5") != "5"
+    print(apteryx.get_tree("/test/settings/users"))
+    assert apteryx.get("/test/settings/users/fred/groups/cat") != "cat"
+    assert apteryx.get("/test/settings/users/fred/groups/5") != "5"
 
 
 def test_restconf_create_list_leaf_integer_invalid_path():
@@ -418,7 +419,7 @@ def test_restconf_create_list_leaf_integer_invalid_path():
     ]
 }
 """
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.post("{}{}/data/test/settings/users=fred/groups".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 405
     assert len(response.content) > 0
@@ -437,8 +438,8 @@ def test_restconf_create_list_leaf_integer_invalid_path():
     }
 }
     """)
-    print(apteryx_traverse("/test/settings/users"))
-    assert apteryx_get("/test/settings/users/fred/groups/cat") != "cat"
+    print(apteryx.get_tree("/test/settings/users"))
+    assert apteryx.get("/test/settings/users/fred/groups/cat") != "cat"
 
 
 def test_restconf_create_complex_ok():
@@ -458,11 +459,11 @@ def test_restconf_create_complex_ok():
 """
     response = requests.post("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 201
-    print(apteryx_traverse("/test/settings/users"))
-    assert apteryx_get("/test/settings/users/fred/name") == "fred"
-    assert apteryx_get("/test/settings/users/fred/age") == "99"
-    assert apteryx_get("/test/settings/users/fred/groups/1") == "1"
-    assert apteryx_get("/test/settings/users/fred/groups/5") == "5"
+    print(apteryx.get_tree("/test/settings/users"))
+    assert apteryx.get("/test/settings/users/fred/name") == "fred"
+    assert apteryx.get("/test/settings/users/fred/age") == "99"
+    assert apteryx.get("/test/settings/users/fred/groups/1") == "1"
+    assert apteryx.get("/test/settings/users/fred/groups/5") == "5"
 
 
 def test_restconf_create_list_entry_exists():
@@ -494,29 +495,29 @@ def test_restconf_create_list_entry_exists():
     }
 }
     """)
-    assert apteryx_get("/test/animals/animal/cat/type") == "1"
+    assert apteryx.get("/test/animals/animal/cat/type") == "1"
 
 
 def test_restconf_create_proxy_string():
-    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/test/settings/description", "")
     data = """{"description": "this is a description via a proxy"}"""
     response = requests.post("{}{}/data/logical-elements:logical-elements/logical-element/loopy/test/settings".format(server_uri, docroot),
                              auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "this is a description via a proxy"
+    assert apteryx.get("/test/settings/description") == "this is a description via a proxy"
 
 
 def test_restconf_create_proxy_string_read_only():
-    apteryx_set("/logical-elements/logical-element-ro/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element-ro/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element-ro/loopy/*", "tcp://127.0.0.1:9999")
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/logical-elements/logical-element-ro/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element-ro/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element-ro/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/test/settings/description", "")
     data = """{"description": "this is a description via a proxy"}"""
     response = requests.post("{}{}/data/logical-elements:logical-elements-ro/logical-element/loopy/test/settings".format(server_uri, docroot),
                              auth=server_auth, headers=set_restconf_headers, data=data)
@@ -562,7 +563,7 @@ def test_restconf_create_if_feature_true():
                              auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/testtime/days") == "1"
+    assert apteryx.get("/test/settings/testtime/days") == "1"
 
 
 def test_restconf_create_when_condition_true():
@@ -577,7 +578,7 @@ def test_restconf_create_when_condition_true():
                              auth=server_auth, headers=set_restconf_headers, data=tree)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/dog/houses/house/kennel") == "kennel"
+    assert apteryx.get("/test/animals/animal/dog/houses/house/kennel") == "kennel"
 
 
 def test_restconf_create_when_condition_false():
@@ -607,13 +608,13 @@ def test_restconf_create_when_condition_false():
 
 
 def test_restconf_when_condition_true():
-    apteryx_set("/test/animals/animal/wombat/name", "wombat")
+    apteryx.set("/test/animals/animal/wombat/name", "wombat")
     data = """{"claws": "5"}"""
     response = requests.post("{}{}/data/test/animals/animal/cat".format(server_uri, docroot),
                              auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/cat/claws") == "5"
+    assert apteryx.get("/test/animals/animal/cat/claws") == "5"
 
 
 def test_restconf_when_condition_false():
@@ -642,11 +643,11 @@ def test_restconf_must_condition_true():
                              auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/dog/friend") == "ben"
+    assert apteryx.get("/test/animals/animal/dog/friend") == "ben"
 
 
 def test_restconf_must_condition_false():
-    apteryx_prune("/test/animals/animal/cat")
+    apteryx.prune("/test/animals/animal/cat")
     data = """{"friend": "ben"}"""
     response = requests.post("{}{}/data/test/animals/animal/dog".format(server_uri, docroot),
                              auth=server_auth, headers=set_restconf_headers, data=data)

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,57 +1,58 @@
+import apteryx
 import json
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_get, apteryx_traverse, get_restconf_headers, set_restconf_headers, apteryx_proxy
+from conftest import server_uri, server_auth, docroot, get_restconf_headers, set_restconf_headers
 
 
 def test_restconf_delete_single_node_ns_none():
     response = requests.delete("{}{}/data/test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "Not found"
+    assert apteryx.get("/test/settings/priority") is None
 
 
 def test_restconf_delete_single_node_ns_aug_none():
     response = requests.delete("{}{}/data/test/settings/volume".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/volume") == "Not found"
+    assert apteryx.get("/test/settings/volume") is None
 
 
 def test_restconf_delete_single_node_ns_default():
     response = requests.delete("{}{}/data/testing:test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "Not found"
+    assert apteryx.get("/test/settings/priority") is None
 
 
 def test_restconf_delete_single_node_ns_aug_default():
     response = requests.delete("{}{}/data/testing:test/settings/volume".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/volume") == "Not found"
+    assert apteryx.get("/test/settings/volume") is None
 
 
 def test_restconf_delete_single_node_ns_other():
     response = requests.delete("{}{}/data/testing-2:test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t2:test/settings/volume") == "Not found"
-    assert apteryx_get("/test/settings/priority") == "1"
+    assert apteryx.get("/t2:test/settings/volume") is None
+    assert apteryx.get("/test/settings/priority") == "1"
 
 
 def test_restconf_delete_single_node_ns_aug_other():
     response = requests.delete("{}{}/data/testing-2:test/settings/testing2-augmented:speed".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t2:test/settings/speed") == "Not found"
-    assert apteryx_get("/t2:test/settings/priority") == "2"
+    assert apteryx.get("/t2:test/settings/speed") is None
+    assert apteryx.get("/t2:test/settings/priority") == "2"
 
 
 def test_restconf_delete_trunk_ns_none():
     response = requests.delete("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    print(apteryx_traverse("/test/animals"))
+    print(apteryx.get_tree("/test/animals"))
     response = requests.get("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert response.json() == json.loads('{}')
@@ -70,8 +71,8 @@ def test_restconf_delete_trunk_ns_other():
     response = requests.delete("{}{}/data/testing-2:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t2:test/settings/priority") == "Not found"
-    assert apteryx_get("/t2:test/settings/speed") == "Not found"
+    assert apteryx.get("/t2:test/settings/priority") is None
+    assert apteryx.get("/t2:test/settings/speed") is None
 
 
 def test_restconf_delete_trunk_denied():
@@ -96,97 +97,97 @@ def test_restconf_delete_trunk_denied():
 
 def test_restconf_delete_trunk_hidden():
     # Remove the readonly field so there is nothing illiegal to delete
-    apteryx_set("/test/settings/readonly", "")
+    apteryx.set("/test/settings/readonly", "")
     response = requests.delete("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "Not found"
-    assert apteryx_get("/test/settings/enable") == "Not found"
-    assert apteryx_get("/test/settings/priority") == "Not found"
-    assert apteryx_get("/test/settings/hidden") == "friend"
+    assert apteryx.get("/test/settings/debug") is None
+    assert apteryx.get("/test/settings/enable") is None
+    assert apteryx.get("/test/settings/priority") is None
+    assert apteryx.get("/test/settings/hidden") == "friend"
 
 
 def test_restconf_delete_trunk_nonschema():
     # Remove the readonly field so there is nothing illiegal to delete
-    apteryx_set("/test/settings/readonly", "")
-    apteryx_set("/test/settings/vegetable", "cabagge")
+    apteryx.set("/test/settings/readonly", "")
+    apteryx.set("/test/settings/vegetable", "cabagge")
     response = requests.delete("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "Not found"
-    assert apteryx_get("/test/settings/enable") == "Not found"
-    assert apteryx_get("/test/settings/priority") == "Not found"
-    assert apteryx_get("/test/settings/hidden") == "friend"
-    assert apteryx_get("/test/settings/vegetable") == "cabagge"
+    assert apteryx.get("/test/settings/debug") is None
+    assert apteryx.get("/test/settings/enable") is None
+    assert apteryx.get("/test/settings/priority") is None
+    assert apteryx.get("/test/settings/hidden") == "friend"
+    assert apteryx.get("/test/settings/vegetable") == "cabagge"
 
 
 def test_restconf_delete_list_select_one():
     response = requests.delete("{}{}/data/testing:test/animals/animal=cat".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/cat/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/cat/type") == "Not found"
-    assert apteryx_get('/test/animals/animal/dog/name') == 'dog'
-    assert apteryx_get('/test/animals/animal/dog/colour') == 'brown'
+    assert apteryx.get("/test/animals/animal/cat/name") is None
+    assert apteryx.get("/test/animals/animal/cat/type") is None
+    assert apteryx.get('/test/animals/animal/dog/name') == 'dog'
+    assert apteryx.get('/test/animals/animal/dog/colour') == 'brown'
 
 
 def test_restconf_delete_list_select_by_path_one():
     response = requests.delete("{}{}/data/testing:test/animals/animal/cat".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/cat/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/cat/type") == "Not found"
-    assert apteryx_get('/test/animals/animal/dog/name') == 'dog'
-    assert apteryx_get('/test/animals/animal/dog/colour') == 'brown'
+    assert apteryx.get("/test/animals/animal/cat/name") is None
+    assert apteryx.get("/test/animals/animal/cat/type") is None
+    assert apteryx.get('/test/animals/animal/dog/name') == 'dog'
+    assert apteryx.get('/test/animals/animal/dog/colour') == 'brown'
 
 
 def test_restconf_delete_list_select_two():
     response = requests.delete("{}{}/data/testing:test/animals/animal=hamster/food=banana".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/hamster/food/banana/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/hamster/food/banana/type") == "Not found"
-    assert apteryx_get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
-    assert apteryx_get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'
+    assert apteryx.get("/test/animals/animal/hamster/food/banana/name") is None
+    assert apteryx.get("/test/animals/animal/hamster/food/banana/type") is None
+    assert apteryx.get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
+    assert apteryx.get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'
 
 
 def test_restconf_delete_list_by_path_select_two():
     response = requests.delete("{}{}/data/testing:test/animals/animal/hamster/food/banana".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/hamster/food/banana/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/hamster/food/banana/type") == "Not found"
-    assert apteryx_get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
-    assert apteryx_get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'
+    assert apteryx.get("/test/animals/animal/hamster/food/banana/name") is None
+    assert apteryx.get("/test/animals/animal/hamster/food/banana/type") is None
+    assert apteryx.get('/test/animals/animal/hamster/food/nuts/name') == 'nuts'
+    assert apteryx.get('/test/animals/animal/hamster/food/nuts/type') == 'kibble'
 
 
 def test_restconf_delete_list_by_path_select_list_leaf():
     response = requests.delete("{}{}/data/testing:test/animals/animal/parrot/toys/toy/puzzles".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/parrot/toys/toy/puzzles") == "Not found"
-    assert apteryx_get("/test/animals/animal/parrot/toys/toy/rings") == 'rings'
+    assert apteryx.get("/test/animals/animal/parrot/toys/toy/puzzles") is None
+    assert apteryx.get("/test/animals/animal/parrot/toys/toy/rings") == 'rings'
 
 
 def test_restconf_delete_proxy_list_select_one():
-    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
     response = requests.delete("{}{}/data/logical-elements:logical-elements/logical-element/loopy/testing:test/animals/animal=dog".format(server_uri, docroot),
                                auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/cat/name") == 'cat'
-    assert apteryx_get('/test/animals/animal/dog/name') == "Not found"
-    assert apteryx_get('/test/animals/animal/dog/colour') == "Not found"
+    assert apteryx.get("/test/animals/animal/cat/name") == 'cat'
+    assert apteryx.get('/test/animals/animal/dog/name') is None
+    assert apteryx.get('/test/animals/animal/dog/colour') is None
 
 
 def test_restconf_delete_proxy_list_select_one_read_only():
-    apteryx_set("/logical-elements/logical-element-ro/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element-ro/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element-ro/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/logical-elements/logical-element-ro/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element-ro/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element-ro/loopy/*", "tcp://127.0.0.1:9999")
     response = requests.delete("{}{}/data/logical-elements:logical-elements/logical-element-ro/loopy/testing:test/animals/animal=dog".format(server_uri, docroot),
                                auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 404

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,6 +1,7 @@
+import apteryx
 import json
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_prune, get_restconf_headers, apteryx_proxy
+from conftest import server_uri, server_auth, docroot, get_restconf_headers
 
 
 def test_restconf_get_single_node_ns_none():
@@ -65,7 +66,7 @@ def test_restconf_get_integer():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads('{ "testing:priority": 1 }')
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     response = requests.get("{}{}/data/testing:test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -74,11 +75,11 @@ def test_restconf_get_integer():
 
 def test_restconf_get_uint64():
     # /test/settings/volume uint64 range="0..18446744073709551615"
-    apteryx_set("/test/settings/volume", "0")
+    apteryx.set("/test/settings/volume", "0")
     response = requests.get("{}{}/data/test/settings/volume".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.json() == json.loads('{ "volume": "0" }')
-    apteryx_set("/test/settings/volume", "18446744073709551615")
+    apteryx.set("/test/settings/volume", "18446744073709551615")
     response = requests.get("{}{}/data/test/settings/volume".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.json() == json.loads('{ "volume": "18446744073709551615" }')
@@ -86,22 +87,22 @@ def test_restconf_get_uint64():
 
 def test_restconf_get_int64():
     # /t2:test/settings/speed int64 range="-9223372036854775808..9223372036854775807"
-    apteryx_set("/t2:test/settings/speed", "-9223372036854775808")
+    apteryx.set("/t2:test/settings/speed", "-9223372036854775808")
     response = requests.get("{}{}/data/testing-2:test/settings/speed".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.json() == json.loads('{ "testing2-augmented:speed": "-9223372036854775808" }')
-    apteryx_set("/t2:test/settings/speed", "0")
+    apteryx.set("/t2:test/settings/speed", "0")
     response = requests.get("{}{}/data/testing-2:test/settings/speed".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.json() == json.loads('{ "testing2-augmented:speed": "0" }')
-    apteryx_set("/t2:test/settings/speed", "9223372036854775807")
+    apteryx.set("/t2:test/settings/speed", "9223372036854775807")
     response = requests.get("{}{}/data/testing-2:test/settings/speed".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.json() == json.loads('{ "testing2-augmented:speed": "9223372036854775807" }')
 
 
 def test_restconf_get_string_string():
-    apteryx_set("/test/settings/description", "This is a description")
+    apteryx.set("/test/settings/description", "This is a description")
     response = requests.get("{}{}/data/testing:test/settings/description".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -109,7 +110,7 @@ def test_restconf_get_string_string():
 
 
 def test_restconf_get_string_number():
-    apteryx_set("/test/settings/description", "123")
+    apteryx.set("/test/settings/description", "123")
     response = requests.get("{}{}/data/testing:test/settings/description".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -122,7 +123,7 @@ def test_restconf_get_boolean():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads('{ "testing:enable": true }')
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/data/testing:test/settings/enable".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -135,7 +136,7 @@ def test_restconf_get_value_string():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads('{ "testing:debug": "enable" }')
-    apteryx_set("/test/settings/debug", "disable")
+    apteryx.set("/test/settings/debug", "disable")
     response = requests.get("{}{}/data/testing:test/settings/debug".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/yang-data+json"
@@ -143,7 +144,7 @@ def test_restconf_get_value_string():
 
 
 def test_restconf_get_node_null():
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/debug", "")
     response = requests.get("{}{}/data/testing:test/settings/debug".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     if len(response.content) != 0:
         print(json.dumps(response.json(), indent=4, sort_keys=True))
@@ -151,7 +152,7 @@ def test_restconf_get_node_null():
 
 
 def test_restconf_get_node_empty():
-    apteryx_set("/test/settings/empty", "empty")
+    apteryx.set("/test/settings/empty", "empty")
     response = requests.get("{}{}/data/testing:test/settings/empty".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -159,7 +160,7 @@ def test_restconf_get_node_empty():
 
 
 def test_restconf_get_trunk_node_empty():
-    apteryx_set("/test/settings/empty", "empty")
+    apteryx.set("/test/settings/empty", "empty")
     response = requests.get("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -349,10 +350,10 @@ def test_restconf_get_list_select_one_by_path_trunk():
 def test_restconf_get_list_reserved_in_key():
     characters = "-._~!$&()*+;=@,: /"
     escaped = "/"
-    apteryx_prune("/test/animals")
+    apteryx.prune("/test/animals")
     for c in characters:
         key = f"skinny%{ord(c):02X}frog" if (c in escaped) else f"skinny{c}frog"
-        apteryx_set(f"/test/animals/animal/{key}/name", f"skinny{c}frog")
+        apteryx.set(f"/test/animals/animal/{key}/name", f"skinny{c}frog")
     response = requests.get("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -394,24 +395,24 @@ def test_restconf_get_leaf_list_node():
 
 
 def test_restconf_get_list_integer_index():
-    apteryx_set("/test/settings/rules/1/index", "1")
-    apteryx_set("/test/settings/rules/1/name", "name1")
-    apteryx_set("/test/settings/rules/99/index", "99")
-    apteryx_set("/test/settings/rules/99/name", "name99")
-    apteryx_set("/test/settings/rules/9/index", "9")
-    apteryx_set("/test/settings/rules/9/name", "name9")
-    apteryx_set("/test/settings/rules/10/index", "10")
-    apteryx_set("/test/settings/rules/10/name", "name10")
-    apteryx_set("/test/settings/rules/5/index", "5")
-    apteryx_set("/test/settings/rules/5/name", "name5")
-    apteryx_set("/test/settings/rules/33/index", "33")
-    apteryx_set("/test/settings/rules/33/name", "name33")
-    apteryx_set("/test/settings/rules/3/index", "3")
-    apteryx_set("/test/settings/rules/3/name", "name3")
-    apteryx_set("/test/settings/rules/111/index", "111")
-    apteryx_set("/test/settings/rules/111/name", "name111")
-    apteryx_set("/test/settings/rules/2/index", "2")
-    apteryx_set("/test/settings/rules/2/name", "name2")
+    apteryx.set("/test/settings/rules/1/index", "1")
+    apteryx.set("/test/settings/rules/1/name", "name1")
+    apteryx.set("/test/settings/rules/99/index", "99")
+    apteryx.set("/test/settings/rules/99/name", "name99")
+    apteryx.set("/test/settings/rules/9/index", "9")
+    apteryx.set("/test/settings/rules/9/name", "name9")
+    apteryx.set("/test/settings/rules/10/index", "10")
+    apteryx.set("/test/settings/rules/10/name", "name10")
+    apteryx.set("/test/settings/rules/5/index", "5")
+    apteryx.set("/test/settings/rules/5/name", "name5")
+    apteryx.set("/test/settings/rules/33/index", "33")
+    apteryx.set("/test/settings/rules/33/name", "name33")
+    apteryx.set("/test/settings/rules/3/index", "3")
+    apteryx.set("/test/settings/rules/3/name", "name3")
+    apteryx.set("/test/settings/rules/111/index", "111")
+    apteryx.set("/test/settings/rules/111/name", "name111")
+    apteryx.set("/test/settings/rules/2/index", "2")
+    apteryx.set("/test/settings/rules/2/name", "name2")
     response = requests.get("{}{}/data/testing:test/settings/rules".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -461,17 +462,17 @@ def test_restconf_get_list_integer_index():
 
 
 def test_restconf_get_leaf_list_integers():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/groups/1", "1")
-    apteryx_set("/test/settings/users/alfred/groups/99", "99")
-    apteryx_set("/test/settings/users/alfred/groups/9", "9")
-    apteryx_set("/test/settings/users/alfred/groups/10", "10")
-    apteryx_set("/test/settings/users/alfred/groups/5", "5")
-    apteryx_set("/test/settings/users/alfred/groups/33", "33")
-    apteryx_set("/test/settings/users/alfred/groups/3", "3")
-    apteryx_set("/test/settings/users/alfred/groups/111", "111")
-    apteryx_set("/test/settings/users/alfred/groups/2", "2")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/groups/1", "1")
+    apteryx.set("/test/settings/users/alfred/groups/99", "99")
+    apteryx.set("/test/settings/users/alfred/groups/9", "9")
+    apteryx.set("/test/settings/users/alfred/groups/10", "10")
+    apteryx.set("/test/settings/users/alfred/groups/5", "5")
+    apteryx.set("/test/settings/users/alfred/groups/33", "33")
+    apteryx.set("/test/settings/users/alfred/groups/3", "3")
+    apteryx.set("/test/settings/users/alfred/groups/111", "111")
+    apteryx.set("/test/settings/users/alfred/groups/2", "2")
     response = requests.get("{}{}/data/testing:test/settings/users=alfred/groups".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -498,7 +499,7 @@ def test_restconf_get_list_leaf_reserved_in_key():
     escaped = "/"
     for c in characters:
         key = f"red%{ord(c):02X}ball" if (c in escaped) else f"red{c}ball"
-        apteryx_set(f"/test/animals/animal/cat/toys/toy/{key}", f"red{c}ball")
+        apteryx.set(f"/test/animals/animal/cat/toys/toy/{key}", f"red{c}ball")
     response = requests.get("{}{}/data/test/animals/animal=cat/toys".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -512,7 +513,7 @@ def test_restconf_get_list_leaf_entry_escaped():
     escaped = "/"
     for c in characters:
         key = f"red%{ord(c):02X}ball" if (c in escaped) else f"red{c}ball"
-        apteryx_set(f"/test/animals/animal/cat/toys/toy/{key}", f"red{c}ball")
+        apteryx.set(f"/test/animals/animal/cat/toys/toy/{key}", f"red{c}ball")
     for c in characters:
         response = requests.get("{}{}/data/test/animals/animal=cat/toys/toy={}".format(server_uri, docroot, f"red%{ord(c):02X}ball"),
                                 auth=server_auth, headers=get_restconf_headers)
@@ -546,17 +547,17 @@ def test_restconf_get_percent_encoded_fields():
 
 
 def test_restconf_get_proxy_value_string():
-    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
     response = requests.get("{}{}/data/logical-elements:logical-elements/logical-element/loopy/testing:test/settings/debug".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads('{ "testing:debug": "enable" }')
-    apteryx_set("/test/settings/debug", "disable")
+    apteryx.set("/test/settings/debug", "disable")
     response = requests.get("{}{}/data/testing:test/settings/debug".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -571,10 +572,10 @@ def test_restconf_get_proxy_value_string():
 
 
 def test_restconf_get_proxy_list_select_one_trunk():
-    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
     response = requests.get("{}{}/data/logical-elements:logical-elements/logical-element/loopy/testing:test/animals/animal=cat".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
@@ -593,7 +594,7 @@ def test_restconf_get_proxy_list_select_one_trunk():
 
 
 def test_restconf_get_when_derived_from():
-    apteryx_set("/test/animals/animal/cat/n-type", "big")
+    apteryx.set("/test/animals/animal/cat/n-type", "big")
     response = requests.get("{}{}/data/testing:test/animals/animal=cat".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
@@ -613,8 +614,8 @@ def test_restconf_get_when_derived_from():
 
 
 def test_restconf_get_when_condition_true():
-    apteryx_set("/test/animals/animal/wombat/name", "wombat")
-    apteryx_set("/test/animals/animal/cat/claws", "5")
+    apteryx.set("/test/animals/animal/wombat/name", "wombat")
+    apteryx.set("/test/animals/animal/cat/claws", "5")
     response = requests.get("{}{}/data/testing:test/animals/animal=cat".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
 
@@ -635,7 +636,7 @@ def test_restconf_get_when_condition_true():
 
 
 def test_restconf_get_when_condition_false():
-    apteryx_set("/test/animals/animal/cat/claws", "5")
+    apteryx.set("/test/animals/animal/cat/claws", "5")
     response = requests.get("{}{}/data/testing:test/animals/animal=cat".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
 
@@ -655,7 +656,7 @@ def test_restconf_get_when_condition_false():
 
 
 def test_restconf_get_must_condition_true():
-    apteryx_set("/test/animals/animal/dog/friend", "ben")
+    apteryx.set("/test/animals/animal/dog/friend", "ben")
     response = requests.get("{}{}/data/testing:test/animals/animal=dog".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
 
@@ -676,8 +677,8 @@ def test_restconf_get_must_condition_true():
 
 
 def test_restconf_get_must_condition_false():
-    apteryx_set("/test/animals/animal/dog/friend", "ben")
-    apteryx_prune("/test/animals/animal/cat")
+    apteryx.set("/test/animals/animal/dog/friend", "ben")
+    apteryx.prune("/test/animals/animal/cat")
     response = requests.get("{}{}/data/testing:test/animals/animal=dog".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,8 @@
+import apteryx
 import json
 import pytest
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, get_restconf_headers, apteryx_proxy
+from conftest import server_uri, server_auth, docroot, get_restconf_headers
 
 
 def test_restconf_query_empty():
@@ -67,12 +68,12 @@ def test_restconf_query_invalid_queries():
 
 
 def test_restconf_query_content_all():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?content=all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -101,12 +102,12 @@ def test_restconf_query_content_all():
 
 
 def test_restconf_query_content_config():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?content=config".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -136,12 +137,12 @@ def test_restconf_query_content_config():
 
 
 def test_restconf_query_content_nonconfig():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?content=nonconfig".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -162,12 +163,12 @@ def test_restconf_query_content_nonconfig():
 
 
 def test_restconf_query_depth_unbounded():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?depth=unbounded".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -210,12 +211,12 @@ def test_restconf_query_depth_1_leaf():
 
 
 def test_restconf_query_depth_1_trunk():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?depth=1".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -224,9 +225,9 @@ def test_restconf_query_depth_1_trunk():
 
 
 def test_restconf_query_depth_1_list():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings/users?depth=1".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -246,12 +247,12 @@ def test_restconf_query_depth_1_list():
 
 
 def test_restconf_query_depth_2_trunk():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?depth=2".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -272,12 +273,12 @@ def test_restconf_query_depth_2_trunk():
 
 
 def test_restconf_query_depth_2_list():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings/users?depth=2".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -296,12 +297,12 @@ def test_restconf_query_depth_2_list():
 
 
 def test_restconf_query_depth_3():
-    apteryx_set("/test/settings/time/day", "5")
-    apteryx_set("/test/settings/time/hour", "12")
-    apteryx_set("/test/settings/time/active", "true")
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/time/day", "5")
+    apteryx.set("/test/settings/time/hour", "12")
+    apteryx.set("/test/settings/time/active", "true")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
     response = requests.get("{}{}/data/test/settings?depth=3".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1042,7 +1043,7 @@ def test_restconf_query_field_ns_bad():
 
 
 def test_restconf_query_with_defaults_explicit_leaf():
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/data/test/settings/debug?with-defaults=explicit".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1055,7 +1056,7 @@ def test_restconf_query_with_defaults_explicit_leaf():
 
 
 def test_restconf_query_with_defaults_trim_leaf():
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/data/test/settings/debug?with-defaults=trim".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1067,7 +1068,7 @@ def test_restconf_query_with_defaults_trim_leaf():
 
 
 def test_restconf_query_with_defaults_report_all_leaf():
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/debug", "")
     response = requests.get("{}{}/data/test/settings/debug?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1097,7 +1098,7 @@ def test_restconf_query_with_defaults_report_all_tagged():
 
 
 def test_restconf_query_with_defaults_explicit_trunk():
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/data/test/settings?with-defaults=explicit".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1117,10 +1118,10 @@ def test_restconf_query_with_defaults_explicit_trunk():
 
 
 def test_restconf_query_with_defaults_trim_trunk_data():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "false")
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "false")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/data/test/settings?with-defaults=trim".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1144,9 +1145,9 @@ def test_restconf_query_with_defaults_trim_trunk_data():
 
 
 def test_restconf_query_with_defaults_report_all_trunk_data():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/debug", "")
     response = requests.get("{}{}/data/test/settings?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1175,12 +1176,12 @@ def test_restconf_query_with_defaults_report_all_trunk_data():
 
 
 def test_restconf_query_with_defaults_report_all_trunk_empty():
-    apteryx_set("/test/settings/debug", "")
-    apteryx_set("/test/settings/enable", "")
-    apteryx_set("/test/settings/priority", "")
-    apteryx_set("/test/settings/hidden", "")
-    apteryx_set("/test/settings/readonly", "")
-    apteryx_set("/test/settings/volume", "")
+    apteryx.set("/test/settings/debug", "")
+    apteryx.set("/test/settings/enable", "")
+    apteryx.set("/test/settings/priority", "")
+    apteryx.set("/test/settings/hidden", "")
+    apteryx.set("/test/settings/readonly", "")
+    apteryx.set("/test/settings/volume", "")
     response = requests.get("{}{}/data/test/settings?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1221,7 +1222,7 @@ def test_restconf_query_with_defaults_empty_list():
 
 
 def test_restconf_query_with_defaults_empty_leaf_list():
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.get("{}{}/data/test/settings/users=fred/groups?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1236,12 +1237,12 @@ def test_restconf_query_with_defaults_empty_leaf_list():
 
 
 def test_restconf_query_with_defaults_explicit_list():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
-    apteryx_set("/test/settings/users/mildred/name", "mildred")
-    apteryx_set("/test/settings/users/mildred/age", "84")
-    apteryx_set("/test/settings/users/mildred/active", "false")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/users/mildred/name", "mildred")
+    apteryx.set("/test/settings/users/mildred/age", "84")
+    apteryx.set("/test/settings/users/mildred/active", "false")
     response = requests.get("{}{}/data/test/settings/users?with-defaults=explicit".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1266,12 +1267,12 @@ def test_restconf_query_with_defaults_explicit_list():
 
 
 def test_restconf_query_with_defaults_trim_list():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
-    apteryx_set("/test/settings/users/mildred/name", "mildred")
-    apteryx_set("/test/settings/users/mildred/age", "84")
-    apteryx_set("/test/settings/users/mildred/active", "false")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/users/mildred/name", "mildred")
+    apteryx.set("/test/settings/users/mildred/age", "84")
+    apteryx.set("/test/settings/users/mildred/active", "false")
     response = requests.get("{}{}/data/test/settings/users?with-defaults=trim".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1295,11 +1296,11 @@ def test_restconf_query_with_defaults_trim_list():
 
 
 def test_restconf_query_with_defaults_report_all_list():
-    apteryx_set("/test/settings/users/alfred/name", "alfred")
-    apteryx_set("/test/settings/users/alfred/age", "87")
-    apteryx_set("/test/settings/users/alfred/active", "true")
-    apteryx_set("/test/settings/users/mildred/name", "mildred")
-    apteryx_set("/test/settings/users/mildred/age", "84")
+    apteryx.set("/test/settings/users/alfred/name", "alfred")
+    apteryx.set("/test/settings/users/alfred/age", "87")
+    apteryx.set("/test/settings/users/alfred/active", "true")
+    apteryx.set("/test/settings/users/mildred/name", "mildred")
+    apteryx.set("/test/settings/users/mildred/age", "84")
     response = requests.get("{}{}/data/test/settings/users?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200
     assert len(response.content) > 0
@@ -1323,11 +1324,11 @@ def test_restconf_query_with_defaults_report_all_list():
 
 
 def test_restconf_query_proxy_with_defaults_report_all_leaf():
-    apteryx_set("/logical-elements/logical-element/loop/name", "loopy")
-    apteryx_set("/logical-elements/logical-element/loop/root", "root")
-    apteryx_set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
-    apteryx_proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
+    apteryx.set("/logical-elements/logical-element/loop/root", "root")
+    apteryx.set("/apteryx/sockets/E18FE205",  "tcp://127.0.0.1:9999")
+    apteryx.proxy("/logical-elements/logical-element/loopy/*", "tcp://127.0.0.1:9999")
+    apteryx.set("/test/settings/debug", "")
     response = requests.get("{}{}/data/logical-elements:logical-elements/logical-element/loopy/test/settings/debug?with-defaults=report-all".format(server_uri, docroot),
                             auth=server_auth, headers=get_restconf_headers)
     assert response.status_code == 200

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -1,8 +1,9 @@
+import apteryx
 import json
 import requests
 import time
 import re
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_get, apteryx_traverse, get_restconf_headers, set_restconf_headers
+from conftest import server_uri, server_auth, docroot, get_restconf_headers, set_restconf_headers
 
 
 def test_restconf_replace_list_entry_new():
@@ -33,11 +34,11 @@ def test_restconf_replace_list_entry_exists():
 """
     response = requests.put("{}{}/data/test/animals/animal".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 204
-    print(apteryx_traverse("/test/animals/animal/cat"))
-    assert apteryx_get("/test/animals/animal/cat") == "Not found"
-    assert apteryx_get("/test/animals/animal/cat/name") == "cat"
-    assert apteryx_get("/test/animals/animal/cat/colour") == "purple"
-    assert apteryx_get("/test/animals/animal/cat/type") == "Not found"
+    print(apteryx.get_tree("/test/animals/animal/cat"))
+    assert apteryx.get("/test/animals/animal/cat") is None
+    assert apteryx.get("/test/animals/animal/cat/name") == "cat"
+    assert apteryx.get("/test/animals/animal/cat/colour") == "purple"
+    assert apteryx.get("/test/animals/animal/cat/type") is None
 
 
 def test_restconf_replace_if_not_modified_since():
@@ -48,7 +49,7 @@ def test_restconf_replace_if_not_modified_since():
     assert response.status_code == 200 and len(response.content) > 0 and response.json() == json.loads('{ "priority": 1 }')
     last_modified = response.headers.get("Last-Modified")
     time.sleep(1)
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     headers = {**get_restconf_headers, 'If-Unmodified-Since': last_modified}
     response = requests.put("{}{}/data/test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=headers, data="""{"priority": "3"}""")
     assert response.status_code == 412
@@ -68,7 +69,7 @@ def test_restconf_replace_if_not_modified_since():
     }
 }
     """)
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_replace_if_not_modified_since_2():
@@ -100,7 +101,7 @@ def test_restconf_replace_if_not_modified_since_2():
     headers = {**get_restconf_headers, 'If-Unmodified-Since': last_modified}
     response = requests.put("{}{}/data/test/settings/priority".format(server_uri, docroot), auth=server_auth, headers=headers, data="""{"priority": 3}""")
     assert response.status_code == 204
-    assert apteryx_get("/test/settings/priority") == "3"
+    assert apteryx.get("/test/settings/priority") == "3"
 
 
 def test_restconf_replace_if_not_modified_since_namespace():
@@ -108,7 +109,7 @@ def test_restconf_replace_if_not_modified_since_namespace():
     assert response.status_code == 200 and len(response.content) > 0 and response.json() == json.loads('{ "testing:priority": 1 }')
     last_modified = response.headers.get("Last-Modified")
     time.sleep(1)
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     headers = {**get_restconf_headers, 'If-Unmodified-Since': last_modified}
     response = requests.put("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=headers, data="""{"testing:priority": "3"}""")
     assert response.status_code == 412
@@ -128,7 +129,7 @@ def test_restconf_replace_if_not_modified_since_namespace():
     }
 }
     """)
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_replace_if_match():
@@ -136,7 +137,7 @@ def test_restconf_replace_if_match():
     assert response.status_code == 200 and len(response.content) > 0 and response.json() == json.loads('{ "priority": 1 }')
     etag = response.headers.get("Etag")
     time.sleep(1)
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     data = """{"priority": "3"}"""
     headers = {**set_restconf_headers, 'If-Match': etag}
     response = requests.put("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=headers, data=data)
@@ -157,7 +158,7 @@ def test_restconf_replace_if_match():
     }
 }
     """)
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_replace_if_match_namespace():
@@ -165,7 +166,7 @@ def test_restconf_replace_if_match_namespace():
     assert response.status_code == 200 and len(response.content) > 0 and response.json() == json.loads('{ "testing:priority": 1 }')
     etag = response.headers.get("Etag")
     time.sleep(1)
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     headers = {**set_restconf_headers, 'If-Match': etag}
     response = requests.put("{}{}/data/testing:test/settings".format(server_uri, docroot), auth=server_auth, headers=headers, data="""{"testing:priority": "3"}""")
     assert response.status_code == 412
@@ -185,7 +186,7 @@ def test_restconf_replace_if_match_namespace():
     }
 }
     """)
-    assert apteryx_get("/test/settings/priority") == "2"
+    assert apteryx.get("/test/settings/priority") == "2"
 
 
 def test_restconf_replace_existing_list_key():

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1,15 +1,16 @@
+import apteryx
 import pytest
 import requests
 import json
 from lxml import etree
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_get
+from conftest import server_uri, server_auth, docroot
 
 
 # TEST CONFIGURATION
 # docroot = '/api'
 search_etag = True
 json_types = True
-APTERYX_URL = ''
+apteryx.URL = ''
 
 
 # TEST HELPERS
@@ -91,7 +92,7 @@ def test_restapi_get_boolean_string():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert response.json() == json.loads('{ "enable": "true" }')
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/test/settings/enable".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -106,7 +107,7 @@ def test_restapi_get_boolean_boolean():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert response.json() == json.loads('{ "enable": true }')
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/test/settings/enable".format(server_uri, docroot), verify=False, auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -120,7 +121,7 @@ def test_restapi_get_enum_value():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert response.json() == json.loads('{ "debug": "1" }')
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/test/settings/debug".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -134,7 +135,7 @@ def test_restapi_get_enum_name():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
     assert response.json() == json.loads('{ "debug": "enable" }')
-    apteryx_set("/test/settings/debug", "0")
+    apteryx.set("/test/settings/debug", "0")
     response = requests.get("{}{}/test/settings/debug".format(server_uri, docroot), verify=False, auth=server_auth, headers=json_headers)
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
@@ -142,7 +143,7 @@ def test_restapi_get_enum_name():
 
 
 def test_restapi_get_node_null():
-    apteryx_set("/test/settings/debug", "")
+    apteryx.set("/test/settings/debug", "")
     response = requests.get("{}{}/test/settings/debug".format(server_uri, docroot), verify=False, auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -151,7 +152,7 @@ def test_restapi_get_node_null():
 
 
 def test_restapi_get_node_empty():
-    apteryx_set("/test/settings/empty", "empty")
+    apteryx.set("/test/settings/empty", "empty")
     response = requests.get("{}{}/test/settings/empty".format(server_uri, docroot), verify=False, auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -160,7 +161,7 @@ def test_restapi_get_node_empty():
 
 
 def test_restapi_get_trunk_node_empty():
-    apteryx_set("/test/settings/empty", "empty")
+    apteryx.set("/test/settings/empty", "empty")
     response = requests.get("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -368,8 +369,8 @@ def test_restapi_get_list_select_one_strings():
 
 
 def test_restapi_get_list_select_one_with_colon():
-    apteryx_set("/test/animals/animal/cat:ty/name", "cat:ty")
-    apteryx_set("/test/animals/animal/cat:ty/type", "1")
+    apteryx.set("/test/animals/animal/cat:ty/name", "cat:ty")
+    apteryx.set("/test/animals/animal/cat:ty/type", "1")
     response = requests.get("{}{}/test/animals/animal/cat:ty".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -385,7 +386,7 @@ def test_restapi_get_list_select_one_with_colon():
 
 
 def test_restapi_get_list_select_one_ns_with_colon():
-    apteryx_set("/t2:test/settings/users/fre:dy/name", "fre:dy")
+    apteryx.set("/t2:test/settings/users/fre:dy/name", "fre:dy")
     response = requests.get("{}{}/t2:test/settings/users/fre:dy".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -485,7 +486,7 @@ def test_restapi_get_etag_changes():
     print(response.headers.get("ETag"))
     assert response.status_code == 200
     assert tag1 == response.headers.get("ETag")
-    apteryx_set("/test/settings/enable", "false")
+    apteryx.set("/test/settings/enable", "false")
     response = requests.get("{}{}/test/settings/enable".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     print(response.headers.get("ETag"))
@@ -510,7 +511,7 @@ def test_restapi_get_etag_not_modified():
 
 
 def test_restapi_get_etag_zero():
-    apteryx_set("/test/settings/enable", "")
+    apteryx.set("/test/settings/enable", "")
     response = requests.get("{}{}/test/settings/enable".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     print(response.headers.get("ETag"))
@@ -539,11 +540,11 @@ def test_restapi_get_hidden_node():
 
 
 def test_restapi_get_hidden_tree():
-    apteryx_set("/test/settings/debug", "")
-    apteryx_set("/test/settings/enable", "")
-    apteryx_set("/test/settings/priority", "")
-    apteryx_set("/test/settings/readonly", "")
-    apteryx_set("/test/settings/volume", "")
+    apteryx.set("/test/settings/debug", "")
+    apteryx.set("/test/settings/enable", "")
+    apteryx.set("/test/settings/priority", "")
+    apteryx.set("/test/settings/readonly", "")
+    apteryx.set("/test/settings/volume", "")
     response = requests.get("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth)
     assert response.status_code == 200
     assert response.json() == json.loads('{}')
@@ -551,7 +552,7 @@ def test_restapi_get_hidden_tree():
 
 # FLAGS_JSON_FORMAT_ROOT=off
 def test_restapi_get_drop_root_string():
-    apteryx_set("/test/settings/description", "This is a description")
+    apteryx.set("/test/settings/description", "This is a description")
     response = requests.get("{}{}/test/settings/description".format(server_uri, docroot), verify=False, auth=server_auth, headers={"X-JSON-Root": "off"})
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -632,63 +633,63 @@ def test_restapi_set_nonjson_string_unquoted():
     response = requests.post("{}{}/test/settings/description".format(server_uri, docroot), verify=False, auth=server_auth, data="This is a description")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "This is a description"
+    assert apteryx.get("/test/settings/description") == "This is a description"
 
 
 def test_restapi_set_nonjson_string_quoted():
     response = requests.post("{}{}/test/settings/description".format(server_uri, docroot), verify=False, auth=server_auth, data='"This is a description"')
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "This is a description"
+    assert apteryx.get("/test/settings/description") == "This is a description"
 
 
 def test_restapi_set_nonjson_number_unquoted():
     response = requests.post("{}{}/test/settings/priority".format(server_uri, docroot), verify=False, auth=server_auth, data='5')
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "5"
+    assert apteryx.get("/test/settings/priority") == "5"
 
 
 def test_restapi_set_nonjson_number_quoted():
     response = requests.post("{}{}/test/settings/priority".format(server_uri, docroot), verify=False, auth=server_auth, data='"5"')
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "5"
+    assert apteryx.get("/test/settings/priority") == "5"
 
 
 def test_restapi_set_nonjson_value_unquoted():
     response = requests.post("{}{}/test/settings/debug".format(server_uri, docroot), verify=False, auth=server_auth, data="disable")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "0"
+    assert apteryx.get("/test/settings/debug") == "0"
 
 
 def test_restapi_set_nonjson_value_quoted():
     response = requests.post("{}{}/test/settings/debug".format(server_uri, docroot), verify=False, auth=server_auth, data='"disable"')
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "0"
+    assert apteryx.get("/test/settings/debug") == "0"
 
 
 def test_restapi_set_nonjson_writeonly():
     response = requests.post("{}{}/test/settings/writeonly".format(server_uri, docroot), verify=False, auth=server_auth, data='"123"')
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/writeonly") == "123"
+    assert apteryx.get("/test/settings/writeonly") == "123"
 
 
 def test_restapi_set_nonjson_readonly():
     response = requests.post("{}{}/test/state/counter".format(server_uri, docroot), verify=False, auth=server_auth, data='"123"')
     assert response.status_code == 403
     assert len(response.content) == 0
-    assert apteryx_get("/test/state/counter") == "42"
+    assert apteryx.get("/test/state/counter") == "42"
 
 
 def test_restapi_set_single_node():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"priority": "5"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "5"
+    assert apteryx.get("/test/settings/priority") == "5"
 
 
 def test_restapi_set_explicit_content_type():
@@ -696,7 +697,7 @@ def test_restapi_set_explicit_content_type():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"priority": "5"}""", headers=headers)
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/priority") == "5"
+    assert apteryx.get("/test/settings/priority") == "5"
 
 
 @pytest.mark.skipif(not json_types, reason="do not support JSON types")
@@ -704,22 +705,22 @@ def test_restapi_set_value_name():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "disable"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "0"
+    assert apteryx.get("/test/settings/debug") == "0"
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "enable"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "1"
+    assert apteryx.get("/test/settings/debug") == "1"
 
 
 def test_restapi_set_value_value():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "0"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "0"
+    assert apteryx.get("/test/settings/debug") == "0"
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "1"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "1"
+    assert apteryx.get("/test/settings/debug") == "1"
 
 
 def test_restapi_set_node_null():
@@ -735,35 +736,35 @@ def test_restapi_set_invalid_path():
     response = requests.post("{}{}/test/cabbage".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "enable"}""")
     assert response.status_code == 404
     assert len(response.content) == 0
-    assert apteryx_get("/test/cabbage/debug") == "Not found"
+    assert apteryx.get("/test/cabbage/debug") is None
 
 
 def test_restapi_set_invalid_enum_value():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"debug": "cabbage"}""")
     assert response.status_code == 400
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/debug") == "1"
+    assert apteryx.get("/test/settings/debug") == "1"
 
 
 def test_restapi_set_readonly():
     response = requests.post("{}{}/test/state".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"counter": "123"}""")
     assert response.status_code == 403
     assert len(response.content) == 0
-    assert apteryx_get("/test/state/counter") == "42"
+    assert apteryx.get("/test/state/counter") == "42"
 
 
 def test_restapi_set_writeonly():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"writeonly": "123"}""")
     assert response.status_code == 200 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/writeonly") == "123"
+    assert apteryx.get("/test/settings/writeonly") == "123"
 
 
 def test_restapi_set_hidden():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"hidden": "cabbage"}""")
     assert response.status_code == 403
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/hidden") == "friend"
+    assert apteryx.get("/test/settings/hidden") == "friend"
 
 
 def test_restapi_set_out_of_range_integer_string():
@@ -775,7 +776,7 @@ def test_restapi_set_out_of_range_integer_string():
     assert response.status_code == 400
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"priority": "55"}""")
     assert response.status_code == 400
-    assert apteryx_get("/test/settings/priority") == "1"
+    assert apteryx.get("/test/settings/priority") == "1"
 
 
 @pytest.mark.skipif(not json_types, reason="do not support JSON types")
@@ -788,7 +789,7 @@ def test_restapi_set_out_of_range_integer_integer():
     assert response.status_code == 400
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"priority": 55}""")
     assert response.status_code == 400
-    assert apteryx_get("/test/settings/priority") == "1"
+    assert apteryx.get("/test/settings/priority") == "1"
 
 
 def test_restapi_set_tree_static():
@@ -1030,18 +1031,18 @@ def test_restapi_set_tree_list_key_ns_colon():
 def test_restapi_set_leaf_list_string():
     response = requests.post("{}{}/test/animals/animal/cat/toys/toy/ball".format(server_uri, docroot), verify=False, auth=server_auth, data="ball")
     assert response.status_code == 201
-    assert apteryx_get("/test/animals/animal/cat/toys/toy/ball") == "ball"
+    assert apteryx.get("/test/animals/animal/cat/toys/toy/ball") == "ball"
 
 
 def test_restapi_set_leaf_list_integer():
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.post("{}{}/test/settings/users/fred/groups/1".format(server_uri, docroot), verify=False, auth=server_auth, data="1")
     assert response.status_code == 201
-    assert apteryx_get("/test/settings/users/fred/groups/1") == "1"
+    assert apteryx.get("/test/settings/users/fred/groups/1") == "1"
 
 
 def test_restapi_set_leaf_list_invalid():
-    apteryx_set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/name", "fred")
     response = requests.post("{}{}/test/settings/users/fred/groups/1".format(server_uri, docroot), verify=False, auth=server_auth, data="cat")
     assert response.status_code == 400
 
@@ -1057,8 +1058,8 @@ def test_restapi_set_leaf_list_array():
     """
     response = requests.post("{}{}/test/animals/animal/cat/toys".format(server_uri, docroot), verify=False, auth=server_auth, headers={"X-JSON-Array": "on"}, data=data)
     assert response.status_code == 201
-    assert apteryx_get("/test/animals/animal/cat/toys/toy/ball") == "ball"
-    assert apteryx_get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"
+    assert apteryx.get("/test/animals/animal/cat/toys/toy/ball") == "ball"
+    assert apteryx.get("/test/animals/animal/cat/toys/toy/mouse") == "mouse"
 
 
 def test_restapi_set_tree_list_full_arrays():
@@ -1176,20 +1177,20 @@ def test_restapi_set_tree_list_full_arrays():
 def test_restapi_set_true_false_string():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"enable": "false"}""")
     assert response.status_code == 200 or response.status_code == 201
-    assert apteryx_get("/test/settings/enable") == "false"
+    assert apteryx.get("/test/settings/enable") == "false"
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"enable": "true"}""")
     assert response.status_code == 200 or response.status_code == 201
-    assert apteryx_get("/test/settings/enable") == "true"
+    assert apteryx.get("/test/settings/enable") == "true"
 
 
 @pytest.mark.skipif(not json_types, reason="do not support JSON types")
 def test_restapi_set_true_false_boolean():
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"enable": false}""")
     assert response.status_code == 200 or response.status_code == 201
-    assert apteryx_get("/test/settings/enable") == "false"
+    assert apteryx.get("/test/settings/enable") == "false"
     response = requests.post("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth, data="""{"enable": true}""")
     assert response.status_code == 200 or response.status_code == 201
-    assert apteryx_get("/test/settings/enable") == "true"
+    assert apteryx.get("/test/settings/enable") == "true"
 
 
 def test_restapi_delete_not_found():
@@ -1234,18 +1235,18 @@ def test_restapi_delete_single_node():
 def test_restapi_delete_trunk():
     response = requests.delete("{}{}/test/settings".format(server_uri, docroot), verify=False, auth=server_auth)
     assert response.status_code == 200 or response.status_code == 204
-    assert apteryx_get("/test/settings/readonly") == "0"
-    assert apteryx_get("/test/settings/hidden") == "friend"
+    assert apteryx.get("/test/settings/readonly") == "0"
+    assert apteryx.get("/test/settings/hidden") == "friend"
 
 
 def test_restapi_delete_list_entry():
     response = requests.delete("{}{}/test/animals/animal/cat".format(server_uri, docroot), verify=False, auth=server_auth)
     assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/animals/animal/cat/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/cat/type") == "Not found"
-    assert apteryx_get('/test/animals/animal/dog/name') == 'dog'
-    assert apteryx_get('/test/animals/animal/dog/colour') == 'brown'
+    assert apteryx.get("/test/animals/animal/cat/name") is None
+    assert apteryx.get("/test/animals/animal/cat/type") is None
+    assert apteryx.get('/test/animals/animal/dog/name') == 'dog'
+    assert apteryx.get('/test/animals/animal/dog/colour') == 'brown'
 
 
 def test_restapi_search_node():
@@ -1261,11 +1262,11 @@ def test_restapi_search_node():
 
 
 def test_restapi_search_empty():
-    apteryx_set("/test/settings/debug", "")
-    apteryx_set("/test/settings/enable", "")
-    apteryx_set("/test/settings/priority", "")
-    apteryx_set("/test/settings/readonly", "")
-    apteryx_set("/test/settings/volume", "")
+    apteryx.set("/test/settings/debug", "")
+    apteryx.set("/test/settings/enable", "")
+    apteryx.set("/test/settings/priority", "")
+    apteryx.set("/test/settings/readonly", "")
+    apteryx.set("/test/settings/volume", "")
     response = requests.get("{}{}/test/settings/".format(server_uri, docroot), verify=False, auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1351,7 +1352,7 @@ def test_restapi_stream_event_node():
     url = "{}{}/test/settings/priority".format(server_uri, docroot)
     response = requests.get(url, stream=True, verify=False, auth=server_auth, headers={'Accept': 'text/event-stream'}, timeout=5)
     assert response.status_code == 200
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     for line in response.iter_lines(decode_unicode=True):
         print(line)
         if line == 'data: {"priority": 2}':
@@ -1362,7 +1363,7 @@ def test_restapi_stream_json_node():
     url = "{}{}/test/settings/priority".format(server_uri, docroot)
     response = requests.get(url, stream=True, verify=False, auth=server_auth, headers={'Accept': 'application/stream+json'}, timeout=5)
     assert response.status_code == 200
-    apteryx_set("/test/settings/priority", "2")
+    apteryx.set("/test/settings/priority", "2")
     for line in response.iter_lines(decode_unicode=True):
         print(line)
         if line and json.loads(line.decode("utf-8")) == json.loads(b'{"priority": 2}'):
@@ -1852,20 +1853,20 @@ def test_restapi_query_field_no_index_2():
 
 
 def test_restapi_rpc_native():
-    apteryx_set("/t4:test/state/age", "100")
+    apteryx.set("/t4:test/state/age", "100")
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_root_namespace():
     headers = {"X-JSON-Types": "on", "X-JSON-Array": "on", "X-JSON-Namespace": "on"}
-    apteryx_set("/t4:test/state/age", "100")
+    apteryx.set("/t4:test/state/age", "100")
     response = requests.post("{}{}/testing-4:test/state/reset".format(server_uri, docroot), auth=server_auth, headers=headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_namespace():
@@ -1876,12 +1877,12 @@ def test_restapi_rpc_namespace():
 
 
 def test_restapi_rpc_empty_input():
-    apteryx_set("/t4:test/state/age", "100")
+    apteryx.set("/t4:test/state/age", "100")
     data = ""
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_with_input():
@@ -1889,7 +1890,7 @@ def test_restapi_rpc_with_input():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "55"
+    assert apteryx.get("/t4:test/state/age") == "55"
 
 
 def test_restapi_rpc_with_input_invalid():
@@ -1897,7 +1898,7 @@ def test_restapi_rpc_with_input_invalid():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 400
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_with_simple_input_integer():
@@ -1905,7 +1906,7 @@ def test_restapi_rpc_with_simple_input_integer():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "55"
+    assert apteryx.get("/t4:test/state/age") == "55"
 
 
 def test_restapi_rpc_with_simple_input_quoted():
@@ -1913,7 +1914,7 @@ def test_restapi_rpc_with_simple_input_quoted():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "55"
+    assert apteryx.get("/t4:test/state/age") == "55"
 
 
 def test_restapi_rpc_with_simple_input_invalid():
@@ -1921,7 +1922,7 @@ def test_restapi_rpc_with_simple_input_invalid():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 400
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_with_simple_input_integer_outofrange():
@@ -1929,11 +1930,11 @@ def test_restapi_rpc_with_simple_input_integer_outofrange():
     response = requests.post("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 400
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restapi_rpc_alternate_operation():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.get("{}{}/t4:test/state/reset".format(server_uri, docroot), auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1949,7 +1950,7 @@ def test_restapi_rpc_invalid_operation():
 
 
 def test_restapi_rpc_with_output_string():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.post("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1958,7 +1959,7 @@ def test_restapi_rpc_with_output_string():
 
 
 def test_restapi_rpc_with_output_integer():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.post("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1967,7 +1968,7 @@ def test_restapi_rpc_with_output_integer():
 
 
 def test_restapi_rpc_with_output_no_root_string():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.post("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth, headers={"X-JSON-Root": "off"})
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1976,7 +1977,7 @@ def test_restapi_rpc_with_output_no_root_string():
 
 
 def test_restapi_rpc_with_output_no_root_json():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.post("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth, headers={"X-JSON-Types": "on", "X-JSON-Root": "off"})
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1985,8 +1986,8 @@ def test_restapi_rpc_with_output_no_root_json():
 
 
 def test_restapi_rpc_with_output_list():
-    apteryx_set("/t4:test/state/history/1", "5")
-    apteryx_set("/t4:test/state/history/2", "55")
+    apteryx.set("/t4:test/state/history/1", "5")
+    apteryx.set("/t4:test/state/history/2", "55")
     response = requests.post("{}{}/t4:test/state/get-reset-history".format(server_uri, docroot), auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -1995,9 +1996,9 @@ def test_restapi_rpc_with_output_list():
 
 
 def test_restapi_rpc_with_output_multiple():
-    apteryx_set("/t4:test/state/age", "5")
-    apteryx_set("/t4:test/state/history/1", "5")
-    apteryx_set("/t4:test/state/history/2", "55")
+    apteryx.set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/history/1", "5")
+    apteryx.set("/t4:test/state/history/2", "55")
     response = requests.post("{}{}/t4:test/state/get-reset-history".format(server_uri, docroot), auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -2014,7 +2015,7 @@ def test_restapi_rpc_with_output_list_empty():
 
 
 def test_restapi_rpc_get_with_output():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.get("{}{}/t4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -2026,7 +2027,7 @@ def test_restapi_rpc_wildcard_no_input():
     response = requests.post("{}{}/t4:test/state/users/fred/set-age".format(server_uri, docroot), auth=server_auth)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/age") == "Not found"
+    assert apteryx.get("/t4:test/state/users/fred/age") is None
 
 
 def test_restapi_rpc_wildcard_with_input():
@@ -2034,12 +2035,12 @@ def test_restapi_rpc_wildcard_with_input():
     response = requests.post("{}{}/t4:test/state/users/fred/set-age".format(server_uri, docroot), auth=server_auth, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/age") == "74"
+    assert apteryx.get("/t4:test/state/users/fred/age") == "74"
 
 
 def test_restapi_rpc_list_get():
-    apteryx_set("/t4:test/state/users/fred/name", "fred")
-    apteryx_set("/t4:test/state/users/fred/age", "24")
+    apteryx.set("/t4:test/state/users/fred/name", "fred")
+    apteryx.set("/t4:test/state/users/fred/age", "24")
     response = requests.get("{}{}/t4:test/state/users".format(server_uri, docroot), auth=server_auth, headers=json_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -2052,29 +2053,29 @@ def test_restapi_rpc_list_create_entry():
     response = requests.post("{}{}/t4:test/state/users".format(server_uri, docroot), verify=False, auth=server_auth, data=data)
     assert response.status_code == 200 or response.status_code == 204 or response.status_code == 201
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/name") == "fred"
-    assert apteryx_get("/t4:test/state/users/fred/age") == "74"
+    assert apteryx.get("/t4:test/state/users/fred/name") == "fred"
+    assert apteryx.get("/t4:test/state/users/fred/age") == "74"
 
 
 def test_restapi_rpc_list_modify_entry():
-    apteryx_set("/t4:test/state/users/fred/name", "fred")
-    apteryx_set("/t4:test/state/users/fred/age", "56")
+    apteryx.set("/t4:test/state/users/fred/name", "fred")
+    apteryx.set("/t4:test/state/users/fred/age", "56")
     data = """{ "age": 33 }"""
     response = requests.put("{}{}/t4:test/state/users/fred".format(server_uri, docroot), verify=False, auth=server_auth, data=data)
     assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/name") == "fred"
-    assert apteryx_get("/t4:test/state/users/fred/age") == "33"
+    assert apteryx.get("/t4:test/state/users/fred/name") == "fred"
+    assert apteryx.get("/t4:test/state/users/fred/age") == "33"
 
 
 def test_restapi_rpc_list_delete_entry():
-    apteryx_set("/t4:test/state/users/fred/name", "fred")
-    apteryx_set("/t4:test/state/users/fred/age", "73")
+    apteryx.set("/t4:test/state/users/fred/name", "fred")
+    apteryx.set("/t4:test/state/users/fred/age", "73")
     response = requests.delete("{}{}/t4:test/state/users/fred".format(server_uri, docroot), verify=False, auth=server_auth)
     assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/name") == "Not found"
-    assert apteryx_get("/t4:test/state/users/fred/age") == "Not found"
+    assert apteryx.get("/t4:test/state/users/fred/name") is None
+    assert apteryx.get("/t4:test/state/users/fred/age") is None
 
 
 def test_restapi_rpc_get_rpcs():

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,27 +1,28 @@
+import apteryx
 import json
 import requests
-from conftest import server_uri, server_auth, docroot, set_restconf_headers, apteryx_get, apteryx_set, apteryx_prune
+from conftest import server_uri, server_auth, docroot, set_restconf_headers
 
 
 def test_restconf_rpc_no_input():
-    apteryx_prune("/system/reboot-info")
+    apteryx.prune("/system/reboot-info")
     response = requests.post("{}{}/operations/testing-4:reboot".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/system/reboot-info/reboot-time") == "Not found"
-    assert apteryx_get("/system/reboot-info/message") == "Not found"
-    assert apteryx_get("/system/reboot-info/language") == "Not found"
+    assert apteryx.get("/system/reboot-info/reboot-time") is None
+    assert apteryx.get("/system/reboot-info/message") is None
+    assert apteryx.get("/system/reboot-info/language") is None
 
 
 def test_restconf_rpc_empty_input():
-    apteryx_prune("/system/reboot-info")
+    apteryx.prune("/system/reboot-info")
     data = ""
     response = requests.post("{}{}/operations/testing-4:reboot".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/system/reboot-info/reboot-time") == "Not found"
-    assert apteryx_get("/system/reboot-info/message") == "Not found"
-    assert apteryx_get("/system/reboot-info/language") == "Not found"
+    assert apteryx.get("/system/reboot-info/reboot-time") is None
+    assert apteryx.get("/system/reboot-info/message") is None
+    assert apteryx.get("/system/reboot-info/language") is None
 
 
 def test_restconf_rpc_with_input():
@@ -36,9 +37,9 @@ def test_restconf_rpc_with_input():
     response = requests.post("{}{}/operations/testing-4:reboot".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/system/reboot-info/reboot-time") == "2"
-    assert apteryx_get("/system/reboot-info/message") == "Rebooting because I can"
-    assert apteryx_get("/system/reboot-info/language") == "Not found"
+    assert apteryx.get("/system/reboot-info/reboot-time") == "2"
+    assert apteryx.get("/system/reboot-info/message") == "Rebooting because I can"
+    assert apteryx.get("/system/reboot-info/language") is None
 
 
 def test_restconf_rpc_invalid_input():
@@ -266,8 +267,8 @@ def test_restconf_rpc_fail_with_message():
 
 
 def test_restconf_rpc_with_output():
-    apteryx_set("/system/reboot-info/reboot-time", "2")
-    apteryx_set("/system/reboot-info/message", "Rebooting because I can")
+    apteryx.set("/system/reboot-info/reboot-time", "2")
+    apteryx.set("/system/reboot-info/message", "Rebooting because I can")
     response = requests.post("{}{}/operations/testing-4:get-reboot-info".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -304,20 +305,20 @@ def test_restconf_rpc_invalid_get_output_node():
 
 
 def test_restconf_action_no_input():
-    apteryx_set("/t4:test/state/age", "100")
+    apteryx.set("/t4:test/state/age", "100")
     response = requests.post("{}{}/data/testing-4:test/state/reset".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restconf_action_empty_input():
-    apteryx_set("/t4:test/state/age", "100")
+    apteryx.set("/t4:test/state/age", "100")
     data = ""
     response = requests.post("{}{}/data/testing-4:test/state/reset".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "Not found"
+    assert apteryx.get("/t4:test/state/age") is None
 
 
 def test_restconf_action_with_input():
@@ -331,7 +332,7 @@ def test_restconf_action_with_input():
     response = requests.post("{}{}/data/testing-4:test/state/reset".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/age") == "55"
+    assert apteryx.get("/t4:test/state/age") == "55"
 
 
 def test_restconf_action_no_input_node():
@@ -402,7 +403,7 @@ def test_restconf_action_invalid_delete_operation():
 
 
 def test_restconf_action_with_output():
-    apteryx_set("/t4:test/state/age", "5")
+    apteryx.set("/t4:test/state/age", "5")
     response = requests.post("{}{}/data/testing-4:test/state/get-last-reset-time".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.status_code == 200
@@ -420,7 +421,7 @@ def test_restconf_rpc_list_no_input():
     response = requests.post("{}{}/data/testing-4:test/state/users=fred/set-age".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/age") == "Not found"
+    assert apteryx.get("/t4:test/state/users/fred/age") is None
 
 
 def test_restconf_rpc_list_with_input():
@@ -434,4 +435,4 @@ def test_restconf_rpc_list_with_input():
     response = requests.post("{}{}/data/testing-4:test/state/users=fred/set-age".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/t4:test/state/users/fred/age") == "74"
+    assert apteryx.get("/t4:test/state/users/fred/age") == "74"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,25 +1,26 @@
+import apteryx
 import json
 import pytest
 import requests
-from conftest import server_uri, server_auth, docroot, apteryx_set, apteryx_get, set_restconf_headers
+from conftest import server_uri, server_auth, docroot, set_restconf_headers
 
 
 def test_restconf_update_string():
-    apteryx_set("/test/settings/description", "previously set")
+    apteryx.set("/test/settings/description", "previously set")
     data = """{"description": "this is a description"}"""
     response = requests.patch("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "this is a description"
+    assert apteryx.get("/test/settings/description") == "this is a description"
 
 
 def test_restconf_update_missing_string():
-    apteryx_set("/test/settings/description", "")
+    apteryx.set("/test/settings/description", "")
     data = """{"description": "this is a description"}"""
     response = requests.patch("{}{}/data/test/settings".format(server_uri, docroot), auth=server_auth, headers=set_restconf_headers, data=data)
     assert response.status_code == 204
     assert len(response.content) == 0
-    assert apteryx_get("/test/settings/description") == "this is a description"
+    assert apteryx.get("/test/settings/description") == "this is a description"
 
 
 def test_restconf_update_existing_list_entry():
@@ -35,9 +36,9 @@ def test_restconf_update_existing_list_entry():
 """
     response = requests.patch("{}{}/data/test/animals".format(server_uri, docroot), auth=server_auth, data=tree, headers=set_restconf_headers)
     assert response.status_code == 204
-    assert apteryx_get("/test/animals/animal/cat/name") == "cat"
-    assert apteryx_get("/test/animals/animal/cat/colour") == "purple"
-    assert apteryx_get("/test/animals/animal/cat/type") == "1"
+    assert apteryx.get("/test/animals/animal/cat/name") == "cat"
+    assert apteryx.get("/test/animals/animal/cat/colour") == "purple"
+    assert apteryx.get("/test/animals/animal/cat/type") == "1"
 
 
 @pytest.mark.skip(reason="should not create a new list entry and return 404")
@@ -70,8 +71,8 @@ def test_restconf_update_missing_list_entry():
     }
 }
     """)
-    assert apteryx_get("/test/animals/animal/frog/name") == "Not found"
-    assert apteryx_get("/test/animals/animal/frog/type") == "Not found"
+    assert apteryx.get("/test/animals/animal/frog/name") is None
+    assert apteryx.get("/test/animals/animal/frog/type") is None
 
 
 def test_restconf_update_existing_list_key():


### PR DESCRIPTION
Makes it easier to pass strings with characters
that might cause issues in the bash shell and also now supports get/set tree