### PR TITLE
Do not blindly percent-decode all URI's

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,3 +417,13 @@ curl -N -H "X-JSON-Types: on" -H "Accept:application/stream+json" http://localho
 {"state": 1}
 {"state": 0}
 ```
+
+## Character encoding
+
+URI syntax as per RFC3986 and RFC8040. Reserved characters that do not form part of the URI syntax should be percent-encoded. URI components are parsed and separated before the percent-encoded octets within those components are decoded.
+
+e.g.
+```
+curl -s -u manager:friend -k https://<HOST>/api/interface/interfaces=port0%2F0%2F1/name | python -m json.tool
+{ "name": "port0/0/1" }
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,25 @@ set_restconf_headers = {"Content-Type": "application/yang-data+json"}
 
 # TEST HELPERS
 
+# Path segments are defined in ABNF grammar as
+# node-identifier = [prefix ":"] identifier
+# prefix = identifier
+# identifier = (ALPHA / "_")*(ALPHA / DIGIT / "_" / "-" / ".")
+# ALPHA = A-Z / a-z
+
+# List keys and leaf-list values in path segments.
+# https://en.wikipedia.org/wiki/Percent-encoding
+# The key value is specified as a string, using the canonical
+# representation for the YANG data type.  Any reserved characters
+# MUST be percent-encoded, according to Sections 2.1 and 2.5 of
+# [RFC3986]. The comma (",") character MUST be percent-encoded if
+# it is present in the key value.
+# NOTE Python requests library will automatically percent-encode
+# or ignore some characters if they are not already percent-encoded
+# e.g. '[]% ' are automatically percent-encoded, '#' is removed?
+# TODO? newline,space,",%,-,.,<,>,\,^,_,`,{,|,},~
+rfc3986_reserved = "!#$&'()*+,/:;=?@[]" + "% "
+
 db_default = [
     # Default namespace
     ('/test/settings/debug', '1'),


### PR DESCRIPTION
As per RFC3986, URI components must be parsed and
separated before the percent-encoded octets within those components can be safely decoded.

Add many tests test we properly handle percent-encoded characters in list keys as this is the primary place reserved URI characters could be encoded.