### PR TITLE
Improve test for pruning tree containing leaf list

### DIFF
--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1364,6 +1364,8 @@ def test_restapi_delete_list_entry():
 def test_restapi_delete_list_entry_with_sublist():
     apteryx.set("/test/settings/users/fred/name", "fred")
     apteryx.set("/test/settings/users/fred/groups/admin", "admin")
+    apteryx.set("/test/settings/users/fred/groups/software", "software")
+    apteryx.set("/test/settings/users/fred/age", "99")
     response = requests.delete("{}{}/test/settings/users/fred".format(server_uri, docroot), verify=False, auth=server_auth)
     assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0


### PR DESCRIPTION
The fixed issue only occurred when the leaf-list was not the first child of the parent. So add leaves to the parent either side of adding the leaf-list to make sure we exercise that scenario.