### PR TITLE
Allow user to override the config-only behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ curl -u manager:friend -k -H "Content-Type: application/json" -d \
 curl -u manager:friend -k -X "DELETE" https://<HOST>/api/firewall/fw_rules/10
 ```
 
+### Delete options
+* Only delete the config (rw) nodes that are descendants of the requested path
+```
+curl -u manager:friend -k -H "X-Config-Only: on" -X "DELETE" https://<HOST>/api/firewall
+```
+
 ## STREAMS
 * Send a GET request with content type text/event-stream to receive asynchronous changes for a path from the server
 

--- a/fcgi.c
+++ b/fcgi.c
@@ -159,6 +159,14 @@ get_flags (FCGX_Request * r)
         flags |= FLAGS_JSON_FORMAT_TYPES;
     if (param && strcmp (param, "off") == 0)
         flags &= ~FLAGS_JSON_FORMAT_TYPES;
+    /* Process config only nodes */
+    param = FCGX_GetParam ("HTTP_X_CONFIG_ONLY", r->envp);
+    if (!param)
+        param = FCGX_GetParam ("HTTP_X-Config-Only", r->envp);
+    if (!(flags & FLAGS_RESTCONF) || (param && strcmp (param, "on") == 0))
+        flags |= FLAGS_CONFIG_ONLY;
+    if (param && strcmp (param, "off") == 0)
+        flags &= ~FLAGS_CONFIG_ONLY;
     /* Prefix model names */
     param = FCGX_GetParam ("HTTP_X_JSON_NAMESPACE", r->envp);
     if (!param)

--- a/internal.h
+++ b/internal.h
@@ -84,6 +84,7 @@ typedef enum
 #define FLAGS_IDREF_VALUES          (1 << 20)
 #define FLAGS_PUT_KEY_VALUE_DATA    (1 << 21)   /* PUT data must be a key:value object */
 #define FLAGS_PUT_REPLACE           (1 << 22)   /* PUT data replaces current contents */
+#define FLAGS_CONFIG_ONLY           (1 << 23)   /* DELETE config only nodes */
 extern int default_accept_encoding;
 extern int default_content_encoding;
 typedef void *req_handle;

--- a/rest.c
+++ b/rest.c
@@ -1391,7 +1391,7 @@ rest_api_delete (int flags, const char *path, const char *remote_user, const cha
         schflags |= SCH_F_JSON_TYPES;
     if (flags & FLAGS_JSON_FORMAT_NS)
         schflags |= SCH_F_NS_MODEL_NAME;
-    else
+    if (flags & FLAGS_CONFIG_ONLY)
         schflags |= SCH_F_CONFIG; /* We only want to delete config-nodes */
 
     /* Generate an aperyx query from the path */

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1383,6 +1383,17 @@ def test_restapi_delete_list_entry_with_empty_sublist():
     assert not apteryx.search("/test/settings/users/")
 
 
+def test_restapi_delete_list_entry_with_sublist_readonly_leaf():
+    apteryx.set("/test/settings/users/fred/name", "fred")
+    apteryx.set("/test/settings/users/fred/active", "true")
+    response = requests.delete(f"{server_uri}{docroot}/test/settings/users/fred", verify=False, auth=server_auth)
+    assert response.status_code == 200 or response.status_code == 204
+    assert len(response.content) == 0
+    print(apteryx.get_tree("/test/settings/users"))
+    assert apteryx.get("/test/settings/users/fred/name") is None
+    assert apteryx.get("/test/settings/users/fred/active") == "true"
+
+
 def test_restapi_delete_list_by_key_with_reserved_characters():
     for c in rfc3986_reserved:
         name = f"fred{c}jones"


### PR DESCRIPTION
Currently restconf aborts if any node in the tree
to be deleted is not rw. It is compliant, but horrible to use. Let the user delete all config in the path by overriding the restconf default behaviour. Note this is the default behaviour for application/json (/api)