### PR TITLE
Modify rest.c to use the changed call to sch_traverse_tree

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -803,35 +803,20 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
 
     /* Query the database */
     tree = apteryx_query (query);
-    if (schflags & SCH_F_ADD_DEFAULTS)
+    if (query && (schflags & SCH_F_ADD_DEFAULTS) && rschema)
     {
-        if (tree)
-        {
-            rnode = get_response_node (tree, rdepth);
-            sch_traverse_tree (g_schema, rschema, rnode, schflags | SCH_F_ADD_DEFAULTS, 0);
-        }
-        else if (qdepth == rdepth && (sch_node_child_first (rschema) || sch_is_leaf (rschema)))
-        {
-            /* Nothing in the database, but we may have defaults! */
-            tree = query;
-            query = NULL;
-            if (g_node_max_height (tree) > qdepth)
-            {
-                GNode *child = g_node_first_child (qnode);
-                qnode->children = NULL;
-                if (child)
-                    apteryx_free_tree (child);
-            }
-            sch_traverse_tree (g_schema, rschema, qnode, schflags | SCH_F_ADD_DEFAULTS, 0);
-        }
+        GNode *rnode = get_response_node (tree, rdepth);
+        sch_add_defaults (g_schema, rschema, &tree, &query, rnode, qnode, rdepth,
+                          qdepth, schflags);
     }
+
     if (tree)
     {
         /* Get rid of any unwanted nodes */
         if (schflags & SCH_F_TRIM_DEFAULTS)
         {
             rnode = get_response_node (tree, rdepth);
-            sch_traverse_tree (g_schema, rschema, rnode, schflags | SCH_F_TRIM_DEFAULTS, 0);
+            sch_traverse_tree (g_schema, rschema, rnode, schflags);
         }
 
         if ((schflags & SCH_F_DEPTH) && param_depth)
@@ -1285,7 +1270,7 @@ rest_api_post (int flags, const char *path, const char *data, int length, const 
     {
         if (!sch_is_leaf (api_subtree))
         {
-            sch_traverse_tree (g_schema, api_subtree, tree, schflags | SCH_F_ADD_MISSING_NULL, 0);
+            sch_traverse_tree (g_schema, api_subtree, tree, schflags | SCH_F_ADD_MISSING_NULL);
         }
     }
 
@@ -1474,7 +1459,7 @@ rest_api_delete (int flags, const char *path, const char *remote_user, const cha
                 }
             }
         }
-        else if (!sch_traverse_tree (g_schema, api_subtree, rnode, schflags | SCH_F_SET_NULL, 0))
+        else if (!sch_traverse_tree (g_schema, api_subtree, rnode, schflags | SCH_F_SET_NULL))
         {
             rc = HTTP_CODE_FORBIDDEN;
             error_tag = REST_E_TAG_ACCESS_DENIED;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,18 @@ db_default = [
     ('/t2:test/settings/speed', '2'),
     # Apteryx namespace
     ('/test3/state/age', '99'),
+    # Data for with-defaults testing
+    ('/interfaces/interface/eth0/name', 'eth0'),
+    ('/interfaces/interface/eth0/mtu', '8192'),
+    ('/interfaces/interface/eth0/status', 'up'),
+    ('/interfaces/interface/eth1/name', 'eth1'),
+    ('/interfaces/interface/eth1/status', 'up'),
+    ('/interfaces/interface/eth2/name', 'eth2'),
+    ('/interfaces/interface/eth2/mtu', '9000'),
+    ('/interfaces/interface/eth2/status', 'not feeling so good'),
+    ('/interfaces/interface/eth3/name', 'eth3'),
+    ('/interfaces/interface/eth3/mtu', '1500'),
+    ('/interfaces/interface/eth3/status', 'waking up'),
 ]
 
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1218,7 +1218,7 @@ def test_restconf_query_with_defaults_empty_node():
     response = requests.get("{}{}/data/testing:test/settings/empty?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
     if len(response.content) != 0:
         print(json.dumps(response.json(), indent=4, sort_keys=True))
-    assert (response.status_code == 204 and len(response.content) == 0) or (response.status_code == 200 and response.json() == json.loads('{}'))
+    assert (response.status_code == 204 and len(response.content) == 0) or (response.status_code == 200 and response.json() == json.loads('{"testing:empty": {}}'))
 
 
 def test_restconf_query_with_defaults_empty_list():
@@ -1228,10 +1228,7 @@ def test_restconf_query_with_defaults_empty_list():
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads("""
-{
-    "users": [
-    ]
-}
+{}
     """)
 
 
@@ -1243,10 +1240,7 @@ def test_restconf_query_with_defaults_empty_leaf_list():
     print(json.dumps(response.json(), indent=4, sort_keys=True))
     assert response.headers["Content-Type"] == "application/yang-data+json"
     assert response.json() == json.loads("""
-{
-    "groups": [
-    ]
-}
+{}
     """)
 
 
@@ -1333,6 +1327,222 @@ def test_restconf_query_with_defaults_report_all_list():
             "name": "mildred"
         }
     ]
+}
+    """)
+
+
+def test_restconf_query_animals_animal_report_all_1():
+    response = requests.get("{}{}/data/test/animals?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "animals": {
+        "animal": [
+            {
+                "name": "cat",
+                "type": "animal-testing-types:big"
+            },
+            {
+                "colour": "brown",
+                "name": "dog",
+                "type": "animal-testing-types:big"
+            },
+            {
+                "food": [
+                    {
+                        "name": "banana",
+                        "type": "fruit"
+                    },
+                    {
+                        "name": "nuts",
+                        "type": "kibble"
+                    }
+                ],
+                "name": "hamster",
+                "type": "animal-testing-types:little"
+            },
+            {
+                "colour": "grey",
+                "name": "mouse",
+                "type": "animal-testing-types:little"
+            },
+            {
+                "colour": "blue",
+                "name": "parrot",
+                "toys": {
+                    "toy": [
+                        "puzzles",
+                        "rings"
+                    ]
+                },
+                "type": "animal-testing-types:big"
+            }
+        ]
+    }
+}
+    """)
+
+
+def test_restconf_query_animals_animal_report_all_2():
+    response = requests.get("{}{}/data/test/animals/animal?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "animal": [
+        {
+            "name": "cat",
+            "type": "animal-testing-types:big"
+        },
+        {
+            "colour": "brown",
+            "name": "dog",
+            "type": "animal-testing-types:big"
+        },
+        {
+            "food": [
+                {
+                    "name": "banana",
+                    "type": "fruit"
+                },
+                {
+                    "name": "nuts",
+                    "type": "kibble"
+                }
+            ],
+            "name": "hamster",
+            "type": "animal-testing-types:little"
+        },
+        {
+            "colour": "grey",
+            "name": "mouse",
+            "type": "animal-testing-types:little"
+        },
+        {
+            "colour": "blue",
+            "name": "parrot",
+            "toys": {
+                "toy": [
+                    "puzzles",
+                    "rings"
+                ]
+            },
+            "type": "animal-testing-types:big"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_query_animals_animal_report_all_3():
+    response = requests.get("{}{}/data/test/animals/animal/dog?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "animal": [
+        {
+            "colour": "brown",
+            "name": "dog",
+            "type": "animal-testing-types:big"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_query_with_defaults_report_all_level_1():
+    response = requests.get("{}{}/data/interfaces/interface?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "interface": [
+        {
+            "mtu": 8192,
+            "name": "eth0",
+            "status": "up"
+        },
+        {
+            "mtu": 1500,
+            "name": "eth1",
+            "status": "up"
+        },
+        {
+            "mtu": 9000,
+            "name": "eth2",
+            "status": "not feeling so good"
+        },
+        {
+            "mtu": 1500,
+            "name": "eth3",
+            "status": "waking up"
+        }
+    ]
+}
+    """)
+
+
+def test_restconf_query_with_defaults_report_all():
+    response = requests.get("{}{}/data/interfaces?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "interfaces": {
+        "interface": [
+            {
+                "mtu": 8192,
+                "name": "eth0",
+                "status": "up"
+            },
+            {
+                "mtu": 1500,
+                "name": "eth1",
+                "status": "up"
+            },
+            {
+                "mtu": 9000,
+                "name": "eth2",
+                "status": "not feeling so good"
+            },
+            {
+                "mtu": 1500,
+                "name": "eth3",
+                "status": "waking up"
+            }
+        ]
+    }
+}
+    """)
+
+
+def test_restconf_query_with_defaults_interfaces_report_all_leaf():
+    response = requests.get("{}{}/data/interfaces/interface/eth0/status?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "status": "up"
+}
+    """)
+
+
+def test_restconf_query_with_defaults_report_all_specific_leaf():
+    response = requests.get("{}{}/data/interfaces/interface/eth1/status?with-defaults=report-all".format(server_uri, docroot), auth=server_auth, headers=get_restconf_headers)
+    assert response.status_code == 200
+    assert len(response.content) > 0
+    print(json.dumps(response.json(), indent=4, sort_keys=True))
+    assert response.json() == json.loads("""
+{
+    "status": "up"
 }
     """)
 


### PR DESCRIPTION
The api for sch_traverse_tree in apteryx-xml/schema.c has been changed. This change modifies rest.c to use the new api.

When processing a "with-defaults" report-all for a query and the query is only for leaf fields, then the routine sch_traverse_tree is no longer called as there can be no additional defaults to add.