### PR TITLE
Fix an issue with exceeding long log messages

### DIFF
--- a/internal.h
+++ b/internal.h
@@ -48,6 +48,10 @@ extern bool verbose;
 #define NOTICE(fmt, args...) { if (debug) printf (fmt, ## args); else syslog (LOG_NOTICE, fmt, ## args); }
 #define ERROR(fmt, args...) { if (debug) printf (fmt, ## args); else syslog (LOG_CRIT, fmt, ## args); }
 
+/* For very long logging lines split the output message up. */
+#define LOG_CHUNK 128
+#define LOG_FLEX 24
+
 typedef enum
 {
     LOG_NONE                    = 0,


### PR DESCRIPTION
If an input value is extremely long, then the resultant log message of the change can be rejected when it is sent the system logger. This change splits the input value into smaller chunks which are individually logged.