### PR TITLE
Get latest timestamp for last-modified http header field

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -804,7 +804,6 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
     /* Get a timestamp for the root of the query path */
     apath = apteryx_node_path (rnode);
     ts = apteryx_timestamp (apath);
-    free (apath);
     if (if_none_match && if_none_match[0] != '\0' &&
         ts == strtoull (if_none_match, NULL, 16))
     {
@@ -930,6 +929,9 @@ exit:
 
     if (!resp)
     {
+        /* Get timestamp after refresher, as there may be some refreshed descendants. */
+        ts = apteryx_timestamp (apath);
+
         if (flags & FLAGS_RESTCONF && rc >= 400 && rc <= 499 && !json_string)
         {
             json_string = restconf_error (rc, error_tag);
@@ -948,6 +950,7 @@ exit:
                                 json_string ? strlen (json_string) : 0,
                                 json_string && (flags & FLAGS_METHOD_HEAD) == 0 ? json_string : "");
     }
+    free (apath);
     free (json_string);
     if (json)
         json_decref (json);


### PR DESCRIPTION
If a child on the path is a refresher, the timestamp set in the last-modified http header field will not be upto date. This is because only refreshers matching the timestamp are triggered, not children.

Get the latest timestamp to store in last-modified http header field after the data has been fetched via apteryx_query().

This makes sure the last-modified field is correct but would not fix if_none_match and if_modified_since timestamp checking when a child of the path is a refresher.