### PR TITLE
Add a flag to force model prefix for X-JSON-Namespace

### DIFF
--- a/fcgi.c
+++ b/fcgi.c
@@ -181,6 +181,10 @@ get_flags (FCGX_Request * r)
         flags |= FLAGS_JSON_FORMAT_NS;
     if (param && strcmp (param, "off") == 0)
         flags &= ~FLAGS_JSON_FORMAT_NS;
+    /* Always include namespace prefix if server is configured to force it */
+    param = FCGX_GetParam ("REST_FORCE_NS_PREFIX", r->envp);
+    if (param && strcmp (param, "on") == 0)
+        flags |= FLAGS_FORCE_NS_PREFIX;
     if (flags & FLAGS_RESTCONF)
         flags |= FLAGS_CONDITIONS | FLAGS_IDREF_VALUES;
     /* PUT flags for RESTCONF compliance */

--- a/internal.h
+++ b/internal.h
@@ -89,6 +89,7 @@ typedef enum
 #define FLAGS_PUT_KEY_VALUE_DATA    (1 << 21)   /* PUT data must be a key:value object */
 #define FLAGS_PUT_REPLACE           (1 << 22)   /* PUT data replaces current contents */
 #define FLAGS_CONFIG_ONLY           (1 << 23)   /* DELETE config only nodes */
+#define FLAGS_FORCE_NS_PREFIX       (1 << 24)   /* Always include namespace prefix in output */
 extern int default_accept_encoding;
 extern int default_content_encoding;
 typedef void *req_handle;

--- a/rest.c
+++ b/rest.c
@@ -720,14 +720,21 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
     if (flags & FLAGS_JSON_FORMAT_NS)
     {
         schflags |= SCH_F_NS_MODEL_NAME;
-        /* If the prefix/model name is not specified in the request
-           then dont include it in the reply */
-        char *colon = strchr (path, ':');
-        char *slash = strchr (path, '/');
-        if (slash)
-            slash = strchr (slash + 1, '/');
-        if (colon && (!slash || colon < slash))
+        if (flags & FLAGS_FORCE_NS_PREFIX)
+        {
             schflags |= SCH_F_NS_PREFIX;
+        }
+        else
+        {
+            /* If the prefix/model name is not specified in the request
+               then dont include it in the reply */
+            char *colon = strchr (path, ':');
+            char *slash = strchr (path, '/');
+            if (slash)
+                slash = strchr (slash + 1, '/');
+            if (colon && (!slash || colon < slash))
+                schflags |= SCH_F_NS_PREFIX;
+        }
     }
 
     /* Convert the path to a GNode tree to use as the base of the apteryx query */


### PR DESCRIPTION
Currently this is conditional on the prefix/model being passed in with the request.

With this change, setting fastcgi_param REST_FORCE_NS_PREFIX to on will include the model name/prefix in the response even if not passed in.

This allows matching behaviour of the appweb handler.