### PR TITLE
Return success for non-restconf delete of sub-fields

### DIFF
--- a/rest.c
+++ b/rest.c
@@ -1533,8 +1533,16 @@ rest_api_delete (int flags, const char *path, const char *remote_user, const cha
         }
         else if (g_node_max_height (tree) <= query_depth)
         {
-            rc = HTTP_CODE_NOT_FOUND;
-            error_tag = REST_E_TAG_INVALID_VALUE;
+            if (flags & FLAGS_RESTCONF)
+            {
+                rc = HTTP_CODE_NOT_FOUND;
+                error_tag = REST_E_TAG_INVALID_VALUE;
+            }
+            else
+            {
+                /* Non-RESTCONF DELETE is idempotent: nothing to delete is success */
+                rc = HTTP_CODE_NO_CONTENT;
+            }
         }
         else if (apteryx_set_tree (tree))
         {

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -251,6 +251,15 @@ def test_restconf_delete_sublist_config_only_readonly_leaf():
     assert apteryx.get("/test/settings/users/fred/active") == "true"
 
 
+def test_restconf_delete_trunk_nothing_to_delete():
+    # With config-only filtering a read-only trunk has nothing to delete, which
+    # reaches the same code path as the non-RESTCONF idempotent case in
+    # test_restapi_delete_read_only_trunk. RESTCONF mode keeps the strict 404 here.
+    response = requests.delete("{}{}/data/testing:test/state".format(server_uri, docroot), auth=server_auth, headers={**set_restconf_headers, 'X-Config-Only': "on"})
+    assert response.status_code == 404
+    assert apteryx.get("/test/state/counter") == "42"
+
+
 def test_restconf_delete_proxy_list_select_one():
     apteryx.set("/logical-elements/logical-element/loop/name", "loopy")
     apteryx.set("/logical-elements/logical-element/loop/root", "root")

--- a/tests/test_restapi.py
+++ b/tests/test_restapi.py
@@ -1337,9 +1337,12 @@ def test_restapi_delete_read_only_node():
 
 
 def test_restapi_delete_read_only_trunk():
+    # Non-RESTCONF is config-only and idempotent: a read-only trunk has nothing
+    # config to delete, so this succeeds (no longer 404) and leaves state intact
     response = requests.delete("{}{}/test/state".format(server_uri, docroot), verify=False, auth=server_auth)
-    assert response.status_code == 403 or response.status_code == 404
+    assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0
+    assert apteryx.get("/test/state/counter") == "42"
 
 
 def test_restapi_delete_hidden_node():
@@ -1441,7 +1444,8 @@ def test_restapi_delete_trunk_with_readonly_leaflist():
     apteryx.set("/test/state/romembers/barney", "barney")
     apteryx.set("/test/state/romembers/wilma", "wilma")
     response = requests.delete(f"{server_uri}{docroot}/test/state", verify=False, auth=server_auth)
-    assert response.status_code == 404  # Nothing to delete
+    # Non-RESTCONF DELETE is idempotent: nothing to delete is success, not 404
+    assert response.status_code == 200 or response.status_code == 204
     assert len(response.content) == 0
     assert apteryx.get("/test/state/romembers/fred") == "fred"
     assert apteryx.get("/test/state/romembers/barney") == "barney"


### PR DESCRIPTION
Non-restconf mode deletes are expected to return success if the object is not there, rather than a 404.  This was not happening if the path to be deleted was a valid schema path, but the parent object of the path was not present.  Change the check for this to only set an error if in restconf mode.

This is to match previous behaviour from appweb handler. There is still one difference from the appweb handler for deletes which is that deletes for non-schema nodes will return 404 rather than 200.

(Also this change is returning 204 rather than 200 but that should be acceptable)