### PR TITLE
Add a flag to present a single list-key entry as a keyed object

### DIFF
--- a/fcgi.c
+++ b/fcgi.c
@@ -185,6 +185,10 @@ get_flags (FCGX_Request * r)
     param = FCGX_GetParam ("REST_FORCE_NS_PREFIX", r->envp);
     if (param && strcmp (param, "on") == 0)
         flags |= FLAGS_FORCE_NS_PREFIX;
+    /* Legacy appweb /api compatibility: present a single list entry keyed by its key, not as a 1-element array */
+    param = FCGX_GetParam ("REST_LEGACY_KEY_AS_OBJECT", r->envp);
+    if (param && strcmp (param, "on") == 0)
+        flags |= FLAGS_LEGACY_KEY_AS_OBJECT;
     if (flags & FLAGS_RESTCONF)
         flags |= FLAGS_CONDITIONS | FLAGS_IDREF_VALUES;
     /* PUT flags for RESTCONF compliance */

--- a/internal.h
+++ b/internal.h
@@ -90,6 +90,7 @@ typedef enum
 #define FLAGS_PUT_REPLACE           (1 << 22)   /* PUT data replaces current contents */
 #define FLAGS_CONFIG_ONLY           (1 << 23)   /* DELETE config only nodes */
 #define FLAGS_FORCE_NS_PREFIX       (1 << 24)   /* Always include namespace prefix in output */
+#define FLAGS_LEGACY_KEY_AS_OBJECT  (1 << 25)   /* Legacy appweb /api: present a by-key list entry as {key:{...}} not [{...}] */
 extern int default_accept_encoding;
 extern int default_content_encoding;
 typedef void *req_handle;

--- a/rest.c
+++ b/rest.c
@@ -780,7 +780,8 @@ rest_api_get (int flags, const char *path, const char *if_none_match, const char
     diff = qdepth - rdepth;
     while (diff--)
         rschema = sch_node_parent (rschema);
-    if (sch_node_parent (rschema) && sch_is_list (sch_node_parent (rschema)))
+    if (!(flags & FLAGS_LEGACY_KEY_AS_OBJECT) &&
+        sch_node_parent (rschema) && sch_is_list (sch_node_parent (rschema)))
     {
         /* We need to present the list rather than the key */
         rschema = sch_node_parent (rschema);


### PR DESCRIPTION
For backwards compatibility with the legacy appweb /api handler, add a REST_LEGACY_KEY_AS_OBJECT option. When enabled, a GET of a single list entry by key is presented as a keyed object {"<key>": {...}} rather than a one-element JSON array [ {...} ], matching the old apteryxHandler behaviour that some API clients depend on even with X-JSON-Array on.

The flag skips the "present the list rather than the key" walk-up in the GET handler, so the key entry is rendered directly and its wrapper kept. It only affects by-key list queries; whole-list and nested lists are unchanged. The option is off unless the caller sets the REST_LEGACY_KEY_AS_OBJECT fastcgi param.

Assisted-by: Claude:claude-opus-4.8